### PR TITLE
Allow non-sequential residue indices in neighbour calculation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ lipyphilic CHANGELOG
 0.3.0 (????-??-??)
 ------------------
 
+* Fix neighbour calculation for non-sequential residue indices
+  Fixes #11
 * Added a tool to calculate interleaflet registration
 
 0.2.0 (2021-02-23)

--- a/tests/lipyphilic/lib/test_neighbours.py
+++ b/tests/lipyphilic/lib/test_neighbours.py
@@ -34,7 +34,7 @@ class TestNeighbours:
         }
     
         assert neighbours.neighbours.shape == (reference['n_residues'], reference['n_residues'])
-        assert (np.sum(neighbours.neighbours.toarray(), axis=0) == 6).all()
+        assert (np.sum(neighbours.neighbours.toarray(), axis=0) == reference['n_neighbours']).all()
         
     def test_neighbours_cutoff10(self, universe):
         
@@ -45,11 +45,34 @@ class TestNeighbours:
         # with cutoff=10, every lipid should have 2 neighbours
         reference = {
             'n_residues': 100,  # there are 200 atoms but 100 lipids in total
-            'n_neighbours': 6,
+            'n_neighbours': 2,
         }
     
         assert neighbours.neighbours.shape == (reference['n_residues'], reference['n_residues'])
-        assert (np.sum(neighbours.neighbours.toarray(), axis=0)).all()
+        assert (np.sum(neighbours.neighbours.toarray(), axis=0) == reference['n_neighbours']).all()
+        
+    def test_subset_lipids(self, universe):
+        
+        neighbours = Neighbours(universe, lipid_sel="name C", cutoff=10)
+        neighbours.run()
+    
+        # it's a hexagonal lattice, but each hexagon is irregular (two sides longer than the other 4)
+        # with cutoff=10, every lipid should have 2 neighbours
+        reference = {
+            'n_residues': 50,
+            'n_neighbours': np.array(
+                [
+                    0, 0, 1, 0, 1, 0, 0, 1, 0, 1,
+                    0, 0, 1, 0, 1, 0, 0, 1, 0, 1,
+                    0, 0, 1, 0, 1, 0, 0, 1, 0, 1,
+                    0, 0, 1, 0, 1, 0, 0, 1, 0, 1,
+                    0, 0, 1, 0, 1, 0, 0, 1, 0, 1
+                ]
+            )
+        }
+    
+        assert neighbours.neighbours.shape == (reference['n_residues'], reference['n_residues'])
+        assert_array_equal(np.sum(neighbours.neighbours.toarray(), axis=0), reference['n_neighbours'])
 
 
 class TestNeighboursExceptions:


### PR DESCRIPTION
Fixes #11 

Changes made in this Pull Request:
 - Allow non-sequential residue indices in neighbour calculation
 - This is done using `scipy.stats.rankdata` to sort the residue indices
 - Add a test that previously failed but now passes

PR Checklist
------------
 - [x] Tests added and passing?
 - [x] Docs added and building?
 - [ ] CHANGELOG updated?
 - [x] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
