### PR TITLE
Initialise analysis subclasses with super

### DIFF
--- a/src/lipyphilic/lib/area_per_lipid.py
+++ b/src/lipyphilic/lib/area_per_lipid.py
@@ -157,8 +157,9 @@ class AreaPerLipid(base.AnalysisBase):
         Leaflet membership can be determined using :class:`lipyphilic.lib.assign_leaflets.AssignLeaflets`.
         
         """
+        super(AreaPerLipid, self).__init__(universe.trajectory)
+
         self.u = universe
-        self._trajectory = self.u.trajectory
         self.membrane = self.u.select_atoms(lipid_sel, updating=False)
         
         if np.array(leaflets).ndim not in [1, 2]:

--- a/src/lipyphilic/lib/assign_leaflets.py
+++ b/src/lipyphilic/lib/assign_leaflets.py
@@ -170,9 +170,9 @@ class AssignLeaflets(base.AnalysisBase):
         flip-flop rates that are currently unaccessible with MD simulations, and thus
         should always occupy either the upper or lower leaflet.
         """
-        
+        super(AssignLeaflets, self).__init__(universe.trajectory)
+
         self.u = universe
-        self._trajectory = self.u.trajectory
         self.membrane = self.u.select_atoms(lipid_sel, updating=False)
 
         if (midplane_sel is not None) ^ (midplane_cutoff is not None):

--- a/src/lipyphilic/lib/flip_flop.py
+++ b/src/lipyphilic/lib/flip_flop.py
@@ -181,8 +181,9 @@ class FlipFlop(base.AnalysisBase):
         Leaflet membership can be determined using :class:`lipyphilic.lib.assign_leaflets.AssignLeaflets`.
         
         """
+        super(FlipFlop, self).__init__(universe.trajectory)
+        
         self.u = universe
-        self._trajectory = self.u.trajectory
         self.membrane = self.u.select_atoms(lipid_sel, updating=False)
         
         if (np.array(leaflets).ndim != 2) or (len(leaflets) != self.membrane.n_residues):

--- a/src/lipyphilic/lib/neighbours.py
+++ b/src/lipyphilic/lib/neighbours.py
@@ -250,8 +250,9 @@ class Neighbours(base.AnalysisBase):
             this cutoff distance (in Å). The default is `10.0`.
         
         """
+        super(Neighbours, self).__init__(universe.trajectory)
+        
         self.u = universe
-        self._trajectory = self.u.trajectory
         self.membrane = self.u.select_atoms(lipid_sel, updating=False)
         
         # to allow for non-sequential resindices

--- a/src/lipyphilic/lib/registration.py
+++ b/src/lipyphilic/lib/registration.py
@@ -31,7 +31,7 @@ lower (:math:`l`) leaflet.
 
 The correlation between the two leaflets, :math:`r_{u/l}`, is then calculated as
 the pearson correlation coefficient between :math:`\rho(x, y)_{u}` and
-:math:`\rho(x, y)_{l}` For more information on interleaflet registrtaion in bilayers
+:math:`\rho(x, y)_{l}`. For more information on interleaflet registration in bilayers
 see `Thallmair et al. (2018) <https://pubs.acs.org/doi/abs/10.1021/acs.jpclett.8b01877>`__.
 
 Input
@@ -239,8 +239,9 @@ class Registration(base.AnalysisBase):
         if not isinstance(leaflets, AssignLeaflets):
             raise ValueError("leaflets must be of type AssignLeaflets")
         
+        super(Registration, self).__init__(leaflets.u.trajectory)
+        
         self.u = leaflets.u
-        self._trajectory = leaflets._trajectory
         self.membrane = leaflets.membrane
         self.leaflets = leaflets.leaflets
         self.start = leaflets.start


### PR DESCRIPTION
Changes made in this Pull Request:

 - All analysis classes now use `super` upon initialisation