### PR TITLE
Scc analysis tool

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,4 +2,9 @@
 Authors
 =======
 
-* Paul Smith - https://nms.kcl.ac.uk/lorenz.lab/wp/?page_id=497
+LiPyphilic was created by Paul Smith.
+
+Authors (chronological)
+-----------------------
+
+* Paul Smith

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ lipyphilic CHANGELOG
 0.4.0 (????-??-??)
 ------------------
 
+* PR#24 Added a tool to calculate the coarse-grained order parameter (Fixes #23)
 * PR#22 Added a tool to calculate orientation of lipids in a bilayer (Fixes #20)
 * PR#21 Added a tool to calculate lipid height in a bilayer (Fixes #19)
 * Better description of analysis tools in the docs

--- a/docs/reference/analyses.rst
+++ b/docs/reference/analyses.rst
@@ -14,6 +14,7 @@ tool, including the APIs, see the following pages:
 * Area per lipid: :mod:`lipyphilic.lib.area_per_lipid`
 * Lipid :math:`z` positions: :mod:`lipyphilic.lib.z_positions`
 * Lipid orientation: :mod:`lipyphilic.lib.z_angles`
+* Lipid order parameter: :mod:`lipyphilic.lib.order_parameter`
 
 
 Assign leaflets: :mod:`lipyphilic.lib.assign_leaflets`
@@ -265,7 +266,7 @@ we can calculate the orientation of each cholesterol molecule as follows:
   from lipyphilic.lib.z_angles import ZAngles
 
   # Load an MDAnalysis Universe
-	u = mda.Universe('production.tpr','production.xtc')
+  u = mda.Universe('production.tpr','production.xtc')
 
   z_angles = ZAngles(
     universe=u,
@@ -280,3 +281,44 @@ The results are stored in a :class:`numpy.ndarray` of shape (n_residues, n_lipid
 
 For more information on this module, including how to return the angles in radians rather
 than degrees, see :mod:`lipyphilic.lib.z_angles`.
+
+
+Lipid order parameter --- :mod:`lipyphilic.lib.order_parameter`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This module provides methods for calculating the coarse-grained orientational order
+parameter acyl tails in a in a lipid bilayer. The coarse-grained order parameter, :math:`S_{CC}`,
+is a measure of the degree of ordering of an acyl tail, based on the assessing the extent
+to which the vector connecting two consecutive tail beads is aligned with the membrane
+normal.
+
+See `Seo et al. (2020) <https://pubs.acs.org/doi/full/10.1021/acs.jpclett.0c01317>`__ for
+a definition of :math:`S_{CC}` and `Piggot et al. (2017)
+<https://pubs.acs.org/doi/full/10.1021/acs.jctc.7b00643>`__ for an excellent discussion
+on acyl tail order parameters in molecular dynamics simulations.
+
+To calculate :math:`S_{CC}`, we need to provide an atom selection for the beads
+in a **single** tails of lipids in the bilayer --- that is, **either** the *sn1* or *sn2*
+tails, not both. If we have performed a MARTINI simulation, we can calculate the
+:math:`S_{CC}` of all *sn1* tails of phospholipids as follows:
+
+.. code:: python
+
+  import MDAnalysis as mda
+  from lipyphilic.lib.order_parameter import SCC
+
+  # Load an MDAnalysis Universe
+  u = mda.Universe('production.tpr','production.xtc')
+
+  scc = SCC(
+    universe=u,
+    tail_sel="name ??1 ??A"
+  )
+  
+The above makes use of the powerful `MDAnalysis selection language
+<https://userguide.mdanalysis.org/stable/selections.html>`__. It will select beads such as
+*GL1* and *AM1* as well as *C1A*, *C2A*, *D2A* etc. This makes it simply to quickly calculate
+:math:`S_{CC}` for the *sn1* tails of all species in a bilayer.
+
+To see how to calculate :math:`S_{CC}` using local membrane normals to define the molecular axes,
+as well as the full API of the class, see :mod:`lipyphilic.lib.order_parameter`.

--- a/docs/reference/lib/order_parameter.rst
+++ b/docs/reference/lib/order_parameter.rst
@@ -1,0 +1,1 @@
+.. automodule:: lipyphilic.lib.order_parameter

--- a/src/lipyphilic/lib/assign_leaflets.py
+++ b/src/lipyphilic/lib/assign_leaflets.py
@@ -329,3 +329,29 @@ class AssignLeaflets(base.AnalysisBase):
         ] = 0
         
         return None
+
+    def filter_leaflets(self, lipid_sel=None, frames=None):
+        """Create a subset of the leaflets results array.
+        
+        Filter either by lipid species or by the trajectory frames, or both.
+
+        Parameters
+        ----------
+        lipid_sel : str, optional
+            MDAnalysis selection string that will be used to select a subset of lipids present
+            in the leaflets results array. The default is `None`, in which case data for all lipids
+            will be returned.
+        frames : numpy.ndarray
+            Array of trajectory frame indices that will be used to create a subset of frames present
+            in the leaflets results array. The default is `None`, in which case data for all frames will
+            be returned.
+        """
+        
+        lipid_sel = "all" if lipid_sel is None else lipid_sel
+        lipids = self.membrane.residues.atoms.select_atoms(lipid_sel)
+        keep_lipids = np.in1d(self.membrane.residues.resindices, lipids.residues.resindices)
+        
+        frames = self.frames if frames is None else np.array(frames)
+        keep_frames = np.in1d(self.frames, frames)
+        
+        return self.leaflets[keep_lipids][:, keep_frames]

--- a/src/lipyphilic/lib/order_parameter.py
+++ b/src/lipyphilic/lib/order_parameter.py
@@ -294,7 +294,6 @@ class SCC(base.AnalysisBase):
         
         """
         
-        
         if not (sn1_scc.frames == sn2_scc.frames).all():
             raise ValueError("sn1_scc and sn2_scc must have been run with the same frames")
         

--- a/src/lipyphilic/lib/order_parameter.py
+++ b/src/lipyphilic/lib/order_parameter.py
@@ -299,7 +299,7 @@ class SCC(base.AnalysisBase):
         
         """
         
-        if not (sn1_scc.frames == sn2_scc.frames).all():
+        if not ((sn1_scc.n_frames == sn2_scc.n_frames) and (sn1_scc.frames == sn2_scc.frames).all()):
             raise ValueError("sn1_scc and sn2_scc must have been run with the same frames")
         
         sn1_resindices = sn1_scc.tails.residues.resindices

--- a/src/lipyphilic/lib/order_parameter.py
+++ b/src/lipyphilic/lib/order_parameter.py
@@ -212,12 +212,12 @@ class SCC(base.AnalysisBase):
         self.tail_residue_mask = {species: self.tails.residues.resnames == species for species in np.unique(self.tails.resnames)}
         
         normals = np.array(normals)
-        if normals.ndim not in [2, 3]:
+        if normals.ndim not in [0, 2, 3]:
             raise ValueError("'normals' must either be a 2D array containing leaflet ids "
                              "of each lipid, or a 3D array containing local membrane normals."
                              )
 
-        if len(normals) != self.tails.n_residues:
+        if normals.ndim > 0 and len(normals) != self.tails.n_residues:
             raise ValueError("The shape of 'normals' must be (n_residues,)")
         
         if normals.ndim == 2:
@@ -231,6 +231,11 @@ class SCC(base.AnalysisBase):
         self.SCC = None
         
     def _prepare(self):
+        
+        if self.normals.ndim == 0:
+            
+            self.normals = np.zeros((self.tails.n_residues, self.n_frames, 3))
+            self.normals[:, :, 2] = 1
         
         if self.normals.shape[1] != self.n_frames:
             raise ValueError("The frames to analyse must be identical to those used "

--- a/src/lipyphilic/lib/order_parameter.py
+++ b/src/lipyphilic/lib/order_parameter.py
@@ -1,0 +1,267 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# lipyphilic --- lipyphilic.readthedocs.io
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+
+r"""Lipid order parameter --- :mod:`lipyphilic.lib.order_parameter`
+===================================================================
+
+:Author: Paul Smith
+:Year: 2021
+:Copyright: GNU Public License v2
+
+This module provides methods for calculating the orientational order parameter
+of lipid tails in a bilayer.
+
+Coarse-grained order parameter
+------------------------------
+
+The class :class:`liyphilic.lib.order_parameter.SCC` calculates the coarse=grained
+order parameter, as defined in
+`Seo et al. (2020) <https://pubs.acs.org/doi/full/10.1021/acs.jpclett.0c01317>`__.
+The coarse-grained order parameter, :math:`S_{CC}`, is defined as:
+
+.. math::
+
+  S_{CC} = \displaystyle \frac{\big \langle 3 \cos2 \theta - 1 \big \rangle}{2}
+
+where :math:`\theta` is the angle between the membrane normal and the vector connecting
+tail beads :math:`n` and :math:`n+1`. Angular brackets denote averages over all beads
+in an acyl tail.
+
+See `Piggot et al. (2017) <https://pubs.acs.org/doi/full/10.1021/acs.jctc.7b00643>`__
+for an excellent discussion on calculating acyl tali order parameters in molecular
+dynamics simulations.
+
+Input
+-----
+
+Required:
+  - *universe* : an MDAnalysis Universe object
+  - *tail_sel* : atom selection for beads in the acyl tail
+
+Options:
+  - *normals* : local membrane normals for each tail at each frame
+
+Output
+------
+
+  - *SCC* : order parameter of each tail at each frame
+
+  
+The :math:`S_{CC}` order parameter data are returned in a :class:`numpy.ndarray`, where each
+row corresponds to an individual lipid and each column corresponds to an individual frame.
+
+Warning
+-------
+
+`tail_sel` should select beads in either the *sn1* **or** *sn2* tails, not both tails.
+
+
+Example usage of :class:`Scc`
+-----------------------------
+
+An MDAnalysis Universe must first be created before using `SCC`::
+
+  import MDAnalysis as mda
+  from lipyphilic.lib.order_parameter import SCC
+
+  u = mda.Universe(tpr, trajectory)
+
+If we have used the MARTINI forcefield to study phospholipid/cholesterol mixture,
+we can calculate the order parameter of the *sn1* of tails of DPPC and DOPC as follows::
+
+  scc_sn1 = SCC(
+    universe=u,
+    tail_sel="name ??A"  # selects C1A, C2A, D2A, C3A, and C4A
+  )
+  
+This will calculate :math:`S_{CC}` of each DOPC and DPPC sn1 tail.
+
+We then select which frames of the trajectory to analyse (`None` will use every
+frame) and choose to display a progress bar (`verbose=True`)::
+  
+  scc_sn1.run(
+    start=None,
+    stop=None,
+    step=None,
+    verbose=True
+  )
+  
+The results are then available in the :attr:`scc_sn1.SCC` attribute as a
+:class:`numpy.ndarray`. The array has the shape (n_residues, n_frames). Each row
+corresponds to an individual lipid and each column to an individual frame.
+
+Likewise, to calculate the :math:`S_{CC}` of the *sn2* tails, we can do::
+
+  scc_sn2 = SCC(
+    universe=u,
+    tail_sel="name ??B"  # selects C1B, C2B, D2B, C3B, and C4B
+  )
+  scc_sn2.run(verbose=True)
+
+And the get a weighted-average :math:`S_{CC}` we can do::
+
+  scc_sn1.weighted_average(scc_sn2)
+  
+which will take into account the number of beads in each tail and return
+an weighted-average :math:`S_{CC}` for each lipid at each frame.
+
+Local membrane normals
+----------------------
+
+By default, the :math:`S_{CC}` is calculated as the angle between the positive
+:math:`z` axis and the vector between two consecutive beads in an acyl tail.
+However, it is also possible to pass the :class:`SCC` local membrane normals
+to use instead of the positive :math:`z` axis.
+
+A simple example would involve first determinig which leaflet each lipid is in
+--- *-1* to indicate the lower leaflet and *1* to indicate the upper leaflet ---
+then passing this information to :class:`SCC`::
+
+  import MDAndalysis as mda
+  from lipyphilic.lib.assign_leaflets import AssignLeaflets
+  from lipyphilic.lib.order_parameter import SCC
+  
+  u = mda.Universe(tpr, trajectory)
+  
+  leaflets = AssignLeaflets(
+      universe=u,
+      lipid_sel="name GL1 GL2 ROH"  # assign all lipids to leaflets, incluing cholesterol (ROH)
+  )
+  leaflets.run(verbose=True)
+  
+  scc_sn1 = SCC(
+    universe=u,
+    tail_sel="name ??A",
+    normals=leaflets.filter_leaflets(lipid_sel="name ??A")  # pass only DPPC/DOPC leaflet info
+  )
+  scc_sn1.run(verbose=True)
+  
+In this case, `leaflets.filter_leaflets("name ??A")` is a :class:`numpy.ndarray`
+that contains the leaflet information for each DPPC and DOPC molecule at each frame.
+It has a shape of (n_residues, n_frames). :class:`SCC` assumes that the data therefore
+correspond to the sign of the local :math:`z`-axis --- *-1* for lipids in the lower
+leaflet and *1* for lipids in the upper leaflet.
+
+You can also calculate local membrane normals using, for example, `MemSurfer
+<https://pubs.acs.org/doi/abs/10.1021/acs.jctc.9b00453>`__. If you store the local
+membrane normals in a :class:`numpy.ndarray` called *normals*, with shape
+(n_residues, n_frames, 3), then you can simply pass these normals to `SCC`::
+
+  scc_sn1 = SCC(
+    universe=u,
+    tail_sel="name ??A",
+    normals=normals
+  )
+  scc_sn1.run(verbose=True)
+
+The class and its methods
+-------------------------
+
+.. autoclass:: SCC
+    :members:
+
+"""
+
+import numpy as np
+
+from lipyphilic.lib import base
+
+
+class SCC(base.AnalysisBase):
+    """Calculate coarse-grained acyl tail ordere parameter.
+    """
+
+    def __init__(self, universe,
+                 tail_sel,
+                 normals=None):
+        """Set up parameters for calculating the SCC.
+
+        Parameters
+        ----------
+        universe : Universe
+            MDAnalysis Universe object
+        tail_sel : str
+            Selection string for atoms in either the sn1 **or** sn2 tail of lipids in the
+            membrane
+       normals : numpy.ndarray, optional
+            Local membrane normals. If the array is 2D and of shape (n_residues, n_frames),
+            the values in the array are taken to correspond to the sign of the 'z'-axis:
+            '-1' for the lower leaflet and '1' for the upper leaflet. If the array is 3D
+            and of shape (n_residues, n_frames, 3) then the values are taken to
+            correspond to the vector components of local membrane normals.
+
+        Tip
+        ----
+
+        Data for 'normals' can be generated using `lipyphilic.lib.assign_leaflets.AssignLeaflets`.
+        """
+        super(SCC, self).__init__(universe.trajectory)
+
+        self.u = universe
+        self.tails = self.u.select_atoms(tail_sel, updating=False)
+        
+        # For fancy slicing of atoms for each species
+        self.tail_atom_mask = {species: self.tails.resnames == species for species in np.unique(self.tails.resnames)}
+        
+        # For assigning Scc to correct lipids
+        self.tail_residue_mask = {species: self.tails.residues.resnames == species for species in np.unique(self.tails.resnames)}
+        
+        normals = np.array(normals)
+        if normals.ndim not in [2, 3]:
+            raise ValueError("'normals' must either be a 2D array containing leaflet ids "
+                             "of each lipid, or a 3D array containing local membrane normals."
+                             )
+
+        if len(normals) != self.tails.n_residues:
+            raise ValueError("The shape of 'normals' must be (n_residues,)")
+        
+        if normals.ndim == 2:
+            
+            normals = np.concatenate(
+                (np.zeros_like(normals)[:, :, np.newaxis], np.zeros_like(normals)[:, :, np.newaxis], np.sign(normals)[:, :, np.newaxis]),
+                axis=2
+            )
+            
+        self.normals = normals
+        self.SCC = None
+        
+    def _prepare(self):
+        
+        if self.normals.shape[1] != self.n_frames:
+            raise ValueError("The frames to analyse must be identical to those used "
+                             "for calculating local membrane normals."
+                             )
+        
+        # Output array
+        self.SCC = np.full(
+            (self.tails.n_residues, self.n_frames),
+            fill_value=np.NaN
+        )
+
+    def _single_frame(self):
+        
+        for species in np.unique(self.tails.resnames):
+                
+            # Reshape positions so the first axis is per residue
+            species_atoms = self.tails[self.tail_atom_mask[species]]
+            tail_pos = species_atoms.positions.reshape(species_atoms.n_residues, -1, 3)
+            
+            cc_vectors = np.diff(tail_pos, axis=1)
+            
+            # Account for PBC
+            for dim in range(3):
+
+                cc_vectors[:, :, dim][cc_vectors[:, :, dim] > self._ts.dimensions[dim] / 2.0] -= self._ts.dimensions[dim]
+                cc_vectors[:, :, dim][cc_vectors[:, :, dim] < -self._ts.dimensions[dim] / 2.0] += self._ts.dimensions[dim]
+            
+            # Calclate SCC using membrane normals
+            tails_normals = self.normals[self.tail_residue_mask[species], self._frame_index][:, np.newaxis, :]
+            cos_theta = np.sum(cc_vectors * tails_normals, axis=2) / (np.linalg.norm(cc_vectors, axis=2) * np.linalg.norm(tails_normals, axis=2))
+            s = (3 * cos_theta**2 - 1) * 0.5
+            
+            self.SCC[self.tail_residue_mask[species], self._frame_index] = np.mean(s, axis=1)

--- a/src/lipyphilic/lib/order_parameter.py
+++ b/src/lipyphilic/lib/order_parameter.py
@@ -26,10 +26,10 @@ The coarse-grained order parameter, :math:`S_{CC}`, is defined as:
 
 .. math::
 
-  S_{CC} = \displaystyle \frac{\big \langle 3 \cos2 \theta - 1 \big \rangle}{2}
+  S_{CC} = \displaystyle \frac{\big \langle 3 \cos^2 \theta - 1 \big \rangle}{2}
 
 where :math:`\theta` is the angle between the membrane normal and the vector connecting
-tail beads :math:`n` and :math:`n+1`. Angular brackets denote averages over all beads
+two consecutive tail beads. Angular brackets denote averages over all beads
 in an acyl tail.
 
 See `Piggot et al. (2017) <https://pubs.acs.org/doi/full/10.1021/acs.jctc.7b00643>`__
@@ -58,7 +58,7 @@ row corresponds to an individual lipid and each column corresponds to an individ
 Warning
 -------
 
-`tail_sel` should select beads in either the *sn1* **or** *sn2* tails, not both tails.
+`tail_sel` should select beads in **either** the *sn1* **or** *sn2* tails, not both tails.
 
 
 Example usage of :class:`Scc`
@@ -188,7 +188,7 @@ class SCC(base.AnalysisBase):
         tail_sel : str
             Selection string for atoms in either the sn1 **or** sn2 tail of lipids in the
             membrane
-       normals : numpy.ndarray, optional
+        normals : numpy.ndarray, optional
             Local membrane normals. If the array is 2D and of shape (n_residues, n_frames),
             the values in the array are taken to correspond to the sign of the 'z'-axis:
             '-1' for the lower leaflet and '1' for the upper leaflet. If the array is 3D
@@ -280,9 +280,9 @@ class SCC(base.AnalysisBase):
         Parameters
         ----------
         sn1_scc : SCC
-            An SCC objecto for which the order parameters have been calculated.
+            An SCC object for which the order parameters have been calculated.
         sn2_scc : SCC
-            An SCC objecto for which the order parameters have been calculated.
+            An SCC object for which the order parameters have been calculated.
         return_indices : bool, optional
             Whether to return the residue indices of each lipid. This is useful is there are
             some residues present in 'sn1_scc' that are not in 'sn2_scc', or vice-versa.

--- a/tests/lipyphilic/lib/test_assign_leaflets.py
+++ b/tests/lipyphilic/lib/test_assign_leaflets.py
@@ -39,12 +39,33 @@ class TestAssignLeaflets:
         assert_array_equal(np.unique(leaflets.leaflets), reference['leaflets_present'])
     
         # first 50 residues are in the upper leaflet (1)
-        # final 50 residues are in the upper leaflet (-1)
+        # final 50 residues are in the lower leaflet (-1)
         reference = {
             'assigned': np.array([[1]] * 50 + [[-1]] * 50)
         }
 
         assert_array_equal(leaflets.leaflets, reference['assigned'])
+        
+    def test_filter_leaflets(self, leaflets):
+        
+        reference = {
+            'n_residues': 50,
+            'n_frames': 1,
+            'leaflets_present': [-1, 1]
+        }
+        
+        filtered_leaflets = leaflets.filter_leaflets(lipid_sel="name C", frames=0)
+        
+        assert filtered_leaflets.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_equal(np.unique(filtered_leaflets), reference['leaflets_present'])
+        
+        # first 25 residues are in the upper leaflet (1)
+        # final 25 residues are in the lower leaflet (-1)
+        reference = {
+            'assigned': np.array([[1]] * 25 + [[-1]] * 25)
+        }
+
+        assert_array_equal(filtered_leaflets, reference['assigned'])
 
 
 class TestAssignLeafletsExceptions:

--- a/tests/lipyphilic/lib/test_order_parameter.py
+++ b/tests/lipyphilic/lib/test_order_parameter.py
@@ -1,0 +1,155 @@
+
+import pytest
+import numpy as np
+import MDAnalysis
+
+from numpy.testing._private.utils import assert_array_almost_equal, assert_array_equal
+
+from lipyphilic._simple_systems.simple_systems import HEX_LAT
+from lipyphilic.lib.order_parameter import SCC
+ 
+ 
+class TestSCC:
+    
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def universe():
+        return MDAnalysis.Universe(HEX_LAT)
+
+    kwargs = {
+        'tail_sel': 'name L C',
+    }
+    
+    def test_SCC(self, universe):
+        
+        scc = SCC(universe, **self.kwargs)
+        scc.run()
+    
+        reference = {
+            'n_residues': 100,
+            'n_frames': 1,
+            'scc': np.full((100, 1), fill_value=-0.5)  # all bonds are perpendicular to the z-axis
+        }
+        
+        assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_almost_equal(scc.SCC, reference['scc'])
+        
+    def test_SCC_normals(self, universe):
+        
+        normals = np.ones((100, 1))
+        
+        scc = SCC(universe, **self.kwargs, normals=normals)
+        scc.run()
+    
+        reference = {
+            'n_residues': 100,
+            'n_frames': 1,
+            'scc': np.full((100, 1), fill_value=-0.5)  # all bonds are perpendicular to the z-axis
+        }
+        
+        assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_almost_equal(scc.SCC, reference['scc'])
+        
+    def test_SCC_normals_3D(self, universe):
+            
+        normals = np.zeros((100, 1, 3))
+        normals[:, :, 2] = 1.0
+        
+        scc = SCC(universe, **self.kwargs, normals=normals)
+        scc.run()
+    
+        reference = {
+            'n_residues': 100,
+            'n_frames': 1,
+            'scc': np.full((100, 1), fill_value=-0.5)  # all bonds are perpendicular to the z-axis
+        }
+        
+        assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_almost_equal(scc.SCC, reference['scc'])
+
+
+class TestSCCWeightedAverage:
+    
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def universe():
+        return MDAnalysis.Universe(HEX_LAT)
+    
+    @pytest.fixture(scope='class')
+    def sn1_scc(self, universe):
+        sn1_scc = SCC(universe, "name L")
+        sn1_scc.run()
+        return sn1_scc
+    
+    @pytest.fixture(scope='class')
+    def sn2_scc(self, universe):
+        sn2_scc = SCC(universe, "name C")
+        sn2_scc.run()
+        return sn2_scc
+    
+    def test_SCC_weighted_average(self, sn1_scc, sn2_scc):
+        
+        scc = SCC.weighted_average(sn1_scc, sn2_scc)
+        
+        reference = {
+            'n_residues': 100,
+            'n_frames': 1,
+            'scc': np.full((100, 1), fill_value=-0.5)  # all bonds are perpendicular to the z-axis
+        }
+
+        assert scc.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_almost_equal(scc, reference['scc'])
+        
+    def test_SCC_weighted_average_indices(self, sn1_scc, sn2_scc):
+        
+        scc, indices = SCC.weighted_average(sn1_scc, sn2_scc, return_indices=True)
+        
+        reference = {
+            'n_residues': 100,
+            'n_frames': 1,
+            'scc': np.full((100, 1), fill_value=-0.5),  # all bonds are perpendicular to the z-axis
+            'indices': np.arange(100)
+        }
+
+        assert scc.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_almost_equal(scc, reference['scc'])
+        assert_array_equal(indices, reference['indices'])
+
+
+class TestSCCExceptions:
+    
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def universe():
+        return MDAnalysis.Universe(HEX_LAT)
+
+    kwargs = {
+        'tail_sel': 'name L C',
+    }
+
+    def test_Exceptions(self, universe):
+            
+        match = "'normals' must either be a 2D array containing leaflet ids "
+        with pytest.raises(ValueError, match=match):
+            SCC(
+                universe=universe,
+                **self.kwargs,
+                normals=np.ones(100)
+            )
+        
+        match = "The shape of 'normals' must be \\(n_residues,\\)"
+        with pytest.raises(ValueError, match=match):
+            SCC(
+                universe=universe,
+                **self.kwargs,
+                normals=np.ones((99, 1))
+            )
+            
+        match = "The frames to analyse must be identical to those used "
+        with pytest.raises(ValueError, match=match):
+            scc = SCC(
+                universe=universe,
+                **self.kwargs,
+                normals=np.ones((100, 2))
+            )
+            scc.run()


### PR DESCRIPTION
Fixes #23 

Changes made in this Pull Request:
 - Added a tool to calculate the coarse-grained order parameter of lipids in a bilayer
 - Local membrane normals that define the molecular axes can be passed to the class 
 - The tool calculates the Scc for **one tail at a time** - the atom selection should cover only the *sn1* tail **or** the *sn2* tail, not both.
 - There is a static method that takes two SCC objects then calculates the weighted-average SCC for each lipid at each frame. The weights are defined by the number of beads in each tail of a lipid.


PR Checklist
------------
 - [x] Tests added and passing?
 - [x] Docs added and building?
 - [x] CHANGELOG updated?
 - [x] AUTHORS updated if necessary?
 - [x] Issue raised and referenced?
