### PR TITLE
Plotting projections of membrane properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ htmlcov
 .vscode
 *.iml
 *.komodoproject
+*.code-workspace
 
 # Complexity
 output/*.html

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ if you use the Area Per Lipid tool please also cite `Freud <https://freud.readth
 
 There is currently no paper describing **lipyphilic**, but we're working on it. In the meantime, if you like what we
 do, please tell everyone you know to check out **lipyphilic**! And if there are things you think we could improve, features
-you would like to see added, or pesky bugs you that need to be fixed, please raise an issue on
+you would like to see added, or pesky bugs that need to be fixed, please raise an issue on
 `github <https://github.com/p-j-smith/lipyphilic/issues>`__.
 
 .. end-description

--- a/docs/reference/analyses.rst
+++ b/docs/reference/analyses.rst
@@ -354,5 +354,5 @@ used to plot, for example, the PMF of cholesterol orientation and height in a bi
 may be used to generate plots of, for example, the area per lipid as a function of :math:`xy` in
 the membrane plane.
 
-See :mod:`lipyphilic.lib.plotting` for the full API of :class:`lipyphilic.lib.plotting.MembraneMap`
-and :class:`lipyphilic.lib.plotting.JointDensity` along with usage examples.
+See :mod:`lipyphilic.lib.plotting` for the full API of :class:`lipyphilic.lib.plotting.JointDensity`
+and :class:`lipyphilic.lib.plotting.ProjectionPlot`.

--- a/src/lipyphilic/lib/order_parameter.py
+++ b/src/lipyphilic/lib/order_parameter.py
@@ -107,8 +107,9 @@ And the get a weighted-average :math:`S_{CC}` we can do::
 
   SCC.weighted_average(scc_sn1, scc_sn2)
   
-which will take into account the number of beads in each tail and return
-an weighted-average :math:`S_{CC}` for each lipid at each frame.
+which will take into account the number of beads in each tail and return a new :class`SCC`
+object whose :attr:`.SCC` attribute contains the weighted-average :math:`S_{CC}` for
+each lipid at each frame.
 
 Local membrane normals
 ----------------------
@@ -158,6 +159,36 @@ membrane normals in a :class:`numpy.ndarray` called *normals*, with shape
     normals=normals
   )
   scc_sn1.run(verbose=True)
+
+  
+:math:`S_{CC}` projected onto the membrane plane
+------------------------------------------------
+
+One the :math:`S_{CC}` has been calculated, it is possible to create a 2D plot of time-averaged
+:math:`S_{CC}` projected onto the membrane plane. This can be done using the
+:func:`liypphilic.lib.SCC.project_SCC` method, which is a wrapper around the more general
+:class:`liypphilic.lib.plotting.ProjectionPlot` class.
+
+If the lipids have been assigned to leaflets, and the weighted average of the sn1 and sn2 tails
+store in and :class:`SCC` object named `scc`, we can plot the projection of the coarse-grained
+order parameter onto the membrane plane as follows::
+  
+  scc_projection = scc.project_SCC(
+    lipid_sel="name ??A ??B",
+    start=-100,
+    stop=None,
+    step=None,
+    filter_by=leaflets.filter_by("name ??A ??B") == -1
+  )
+  
+The order parameter of each lipid parameter will be averaged over the final 100 frames, as
+specified by the :attr:`start` argument. The frame in the middle of the selected frames will be used
+for determing lipid positions. In the above case, the lipid positions at frame :math:`-50` will be used.
+The :attr:`lipid_sel` specifies that the center-of-mass of the sn1 ("??A") and sn2 ("??B") a lipid will
+be used for projecting lipid positions onto the membrane plane. And the `filter_by` argument is used here
+to specificy that only lipids in the lower (-1) leaflet should be used for plotting the projected
+:math:`S_{CC}` values.
+  
 
 The class and its methods
 -------------------------
@@ -378,8 +409,7 @@ class SCC(base.AnalysisBase):
         plane based on the center of mass of each lipid.
         
         This method creates an instance of `lipyphilic.lib.plotting.ProjectionPlot` with
-        sensible values, such as getting the extent of the plot based on system dimensons
-        and setting the colorbar scale to be in the range [-0.5, 1.0].
+        project :math:`S_{CC}` interpolated across periodic boundaries.
         The plot is returned so further modification can be performed if needed.
         
         Note

--- a/src/lipyphilic/lib/order_parameter.py
+++ b/src/lipyphilic/lib/order_parameter.py
@@ -103,7 +103,7 @@ Likewise, to calculate the :math:`S_{CC}` of the *sn2* tails, we can do::
   )
   scc_sn2.run(verbose=True)
 
-And the get a weighted-average :math:`S_{CC}` we can do::
+And then get a weighted-average :math:`S_{CC}` we can do::
 
   SCC.weighted_average(scc_sn1, scc_sn2)
   
@@ -138,7 +138,7 @@ then passing this information to :class:`SCC`::
   scc_sn1 = SCC(
     universe=u,
     tail_sel="name ??A",
-    normals=leaflets.filter_leaflets(lipid_sel="name ??A")  # pass only DPPC/DOPC leaflet info
+    normals=leaflets.filter_leaflets(lipid_sel="resname DOPC DPPC")  # pass only DPPC/DOPC leaflet info
   )
   scc_sn1.run(verbose=True)
   
@@ -164,13 +164,13 @@ membrane normals in a :class:`numpy.ndarray` called *normals*, with shape
 :math:`S_{CC}` projected onto the membrane plane
 ------------------------------------------------
 
-One the :math:`S_{CC}` has been calculated, it is possible to create a 2D plot of time-averaged
-:math:`S_{CC}` projected onto the membrane plane. This can be done using the
+Once the :math:`S_{CC}` has been calculated, it is possible to create a 2D plot of time-averaged
+:math:`S_{CC}` values projected onto the membrane plane. This can be done using the
 :func:`liypphilic.lib.SCC.project_SCC` method, which is a wrapper around the more general
 :class:`liypphilic.lib.plotting.ProjectionPlot` class.
 
 If the lipids have been assigned to leaflets, and the weighted average of the sn1 and sn2 tails
-store in and :class:`SCC` object named `scc`, we can plot the projection of the coarse-grained
+stored in an :class:`SCC` object named `scc`, we can plot the projection of the coarse-grained
 order parameter onto the membrane plane as follows::
   
   scc_projection = scc.project_SCC(
@@ -183,8 +183,8 @@ order parameter onto the membrane plane as follows::
   
 The order parameter of each lipid parameter will be averaged over the final 100 frames, as
 specified by the :attr:`start` argument. The frame in the middle of the selected frames will be used
-for determing lipid positions. In the above case, the lipid positions at frame :math:`-50` will be used.
-The :attr:`lipid_sel` specifies that the center-of-mass of the sn1 ("??A") and sn2 ("??B") a lipid will
+for determining lipid positions. In the above case, the lipid positions at frame :math:`-50` will be used.
+The :attr:`lipid_sel` specifies that the center of mass of the sn1 ("??A") and sn2 ("??B") atoms will
 be used for projecting lipid positions onto the membrane plane. And the `filter_by` argument is used here
 to specificy that only lipids in the lower (-1) leaflet should be used for plotting the projected
 :math:`S_{CC}` values.
@@ -405,11 +405,12 @@ class SCC(base.AnalysisBase):
       ):
         """Project the SCC values onto the xy plane of the membrane.
         
-        The SCC values, average over a selected range of frames, are projected onto the xy
-        plane based on the center of mass of each lipid.
+        The SCC values, averaged over a selected range of frames, are projected onto the xy
+        plane based on the center of mass of each lipid. The atoms to be used in calculating
+        the center of mass of the lipids can be specified using the `lipid_sel` arugment.
         
         This method creates an instance of `lipyphilic.lib.plotting.ProjectionPlot` with
-        project :math:`S_{CC}` interpolated across periodic boundaries.
+        the projected :math:`S_{CC}` interpolated across periodic boundaries.
         The plot is returned so further modification can be performed if needed.
         
         Note

--- a/src/lipyphilic/lib/order_parameter.py
+++ b/src/lipyphilic/lib/order_parameter.py
@@ -432,8 +432,7 @@ class SCC(base.AnalysisBase):
             ``combination``
               A combination [int, array] or [array, int], where int is the number of bins and array is the bin edges.
               
-              The default is `None`, in which case a 100 by 100 grid will be created based on the system
-              dimensions in x and y.
+              The default is `None`, in which case a grid with 1 x 1 Angstrom resolution is created.
         
         ax: Axes, optional
             Matplotlib Axes on which to plot the projection. The default is `None`,
@@ -465,7 +464,7 @@ class SCC(base.AnalysisBase):
         if filter_by is not None:
             filter_by = np.array(filter_by)
             
-            if not ((self.SCC.shape == filter_by.shape) or (len(self.SCC) == filter_by.shape)):
+            if not ((self.SCC.shape == filter_by.shape) or (self.SCC.shape[:1] == filter_by.shape)):
                 raise ValueError("The shape of `filter_by` must either be (n_lipids, n_frames) or (n_lipids)")
         
         # Check which lipids to use
@@ -487,7 +486,7 @@ class SCC(base.AnalysisBase):
         if filter_by is None:
             filter_by = np.full(scc.shape[0], fill_value=True)
             
-        elif filter_by.shape == self.SCC.shape[0]:
+        elif filter_by.shape == self.SCC.shape[:1]:
             filter_by = filter_by[keep_lipids]
             
         else:
@@ -513,8 +512,13 @@ class SCC(base.AnalysisBase):
         
         # create grid of values
         if bins is None:
-            x_bins = np.linspace(0.0, self.u.dimensions[0], 200)
-            y_bins = np.linspace(0.0, self.u.dimensions[1], 200)
+              
+            x_dim = self.u.dimensions[0]
+            x_bins = np.linspace(0.0, np.ceil(x_dim), int(np.ceil(x_dim)) + 1)
+            
+            y_dim = self.u.dimensions[1]
+            y_bins = np.linspace(0.0, np.ceil(y_dim), int(np.ceil(y_dim)) + 1)
+              
             bins = (x_bins, y_bins)
         
         scc_projection.project_values(bins=bins)

--- a/src/lipyphilic/lib/plotting.py
+++ b/src/lipyphilic/lib/plotting.py
@@ -21,7 +21,7 @@ to get the end result.
 This module provides methods for plotting joint probability densities and lateral
 distribution maps of lipid properties projected onto the membrane plane.
 
-The class :class:`lipyphilic.lib.plotting.MembraneMap` can be used, for example, to plot
+The class :class:`lipyphilic.lib.plotting.ProjectionPlot` can be used, for example, to plot
 the area per lipid projected onto the membrane plane, i.e. plot the area per lipid
 as a function of :math:`xy`. See `Gu et al. (2020)
 <https://pubs.acs.org/doi/full/10.1021/jacs.9b11057>`__ for examples of these
@@ -34,6 +34,9 @@ for an example of the this 2D PMF.
 
 The classes and their methods
 -----------------------------
+
+.. autoclass:: ProjectionPlot
+    :members:
 
 .. autoclass:: JointDensity
     :members:

--- a/src/lipyphilic/lib/plotting.py
+++ b/src/lipyphilic/lib/plotting.py
@@ -55,6 +55,10 @@ class ProjectionPlot:
         self.x_edges = None
         self.y_edges = None
         
+        self.fig = None
+        self.ax = None
+        self.cbar = None
+        
     def project_values(self, bins, statisitc="mean"):
         """Discretise the membrane and project values onto the xy-plane
         

--- a/tests/lipyphilic/lib/test_order_parameter.py
+++ b/tests/lipyphilic/lib/test_order_parameter.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 import MDAnalysis
 
-from numpy.testing._private.utils import assert_array_almost_equal, assert_array_equal
+from numpy.testing._private.utils import assert_array_almost_equal
 
 from lipyphilic._simple_systems.simple_systems import HEX_LAT
 from lipyphilic.lib.order_parameter import SCC
@@ -97,8 +97,8 @@ class TestSCCWeightedAverage:
             'scc': np.full((50, 1), fill_value=-0.5)  # all bonds are perpendicular to the z-axis
         }
 
-        assert scc.shape == (reference['n_residues'], reference['n_frames'])
-        assert_array_almost_equal(scc, reference['scc'])
+        assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_almost_equal(scc.SCC, reference['scc'])
         
     def test_SCC_weighted_average_different_tails(self, sn1_scc, sn2_scc):
         
@@ -110,23 +110,21 @@ class TestSCCWeightedAverage:
             'scc': np.full((100, 1), fill_value=-0.5)  # all bonds are perpendicular to the z-axis
         }
 
-        assert scc.shape == (reference['n_residues'], reference['n_frames'])
-        assert_array_almost_equal(scc, reference['scc'])
+        assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_almost_equal(scc.SCC, reference['scc'])
         
     def test_SCC_weighted_average_indices(self, sn1_scc, sn2_scc):
         
-        scc, indices = SCC.weighted_average(sn1_scc, sn2_scc, return_indices=True)
+        scc = SCC.weighted_average(sn1_scc, sn2_scc)
         
         reference = {
             'n_residues': 100,
             'n_frames': 1,
             'scc': np.full((100, 1), fill_value=-0.5),  # all bonds are perpendicular to the z-axis
-            'indices': np.arange(100)
         }
 
-        assert scc.shape == (reference['n_residues'], reference['n_frames'])
-        assert_array_almost_equal(scc, reference['scc'])
-        assert_array_equal(indices, reference['indices'])
+        assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_almost_equal(scc.SCC, reference['scc'])
 
 
 class TestSCCExceptions:

--- a/tests/lipyphilic/lib/test_plotting.py
+++ b/tests/lipyphilic/lib/test_plotting.py
@@ -148,6 +148,9 @@ class TestProjectionPlot:
         
     def test_no_cbar(self, projection):
         
+        # `projection_data` has already been used to create a plot with a cbar, and because the
+        # scope of this object is this class, the cbar attribute is not None
+        # So we use create a fresh plot with `projection`, which has not yet been used for plotting
         projection.plot_projection(cbar=False)
         
         assert projection.cbar is None


### PR DESCRIPTION
Changes made in this Pull Request:
 - Added a class `ProjectionPlot` to plot projections of membrane properties (e.g. area per lipid, lipid order parameter) onto the 2D membrane plane
 - Uses `matplotlib.pyplot.imshow` for plotting
 - Added a method `project_SCC` to to `lipyphilic.lib.order_parameters.SCC` that calculates time-averaged order parameters for each lipid and projects this onto the membrane plane using `ProjectionPlot`
 - Modified `lipyphilic.lib.order_parameters.SCC.weighted_average` to return a new `SCC` object rather than a NumPy array. This allows using `project_SCC` with the averaged order parameters.
 - Added tests for the new class and method
 - Updated docs


PR Checklist
------------
 - [x] Tests added and passing?
 - [x] Docs added and building?
 - [ ] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
