### PR TITLE
ZThickness.average() returns a new ZThickness object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ lipyphilic CHANGELOG
 0.5.0 (????-??-??)
 ------------------
 
-* SCC.weighted_average() now returns a new SCC object rather than a NumPy array
+* PR#32 ZThickness.average() now returns a new ZThickness object rather than a NumPy array
+* PR#31 SCC.weighted_average() now returns a new SCC object rather than a NumPy array
 * PR#30 Add class for plotting projections of membrane properties onto the xy plane.
 * PR#29 Added plotting of joint probability distributions or PMFs (Fixed #28).
 

--- a/tests/lipyphilic/lib/test_z_thickness.py
+++ b/tests/lipyphilic/lib/test_z_thickness.py
@@ -64,8 +64,9 @@ class TestZThicknessAverage:
             'z_thickness': np.full((25, 1), fill_value=20)
         }
 
-        assert thickness.shape == (reference['n_residues'], reference['n_frames'])
-        assert_array_almost_equal(thickness, reference['z_thickness'])
+        assert isinstance(thickness, ZThickness)
+        assert thickness.z_thickness.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_almost_equal(thickness.z_thickness, reference['z_thickness'])
         
     def test_ZThickness_average_different_tails(self, sn1_thickness, sn2_thickness):
         
@@ -77,23 +78,8 @@ class TestZThicknessAverage:
             'z_thickness': np.full((50, 1), fill_value=20)
         }
 
-        assert thickness.shape == (reference['n_residues'], reference['n_frames'])
-        assert_array_almost_equal(thickness, reference['z_thickness'])
-        
-    def test_ZThickness_average_indices(self, sn1_thickness, sn2_thickness):
-        
-        thickness, indices = ZThickness.average(sn1_thickness, sn2_thickness, return_indices=True)
-        
-        reference = {
-            'n_residues': 50,
-            'n_frames': 1,
-            'z_thickness': np.full((50, 1), fill_value=20),
-            'indices': np.arange(50)
-        }
-
-        assert thickness.shape == (reference['n_residues'], reference['n_frames'])
-        assert_array_almost_equal(thickness, reference['z_thickness'])
-        assert_array_equal(indices, reference['indices'])
+        assert thickness.z_thickness.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_almost_equal(thickness.z_thickness, reference['z_thickness'])
         
 
 class TestZThicknessAverageExceptions:


### PR DESCRIPTION
Changes made in this Pull Request:
 - ZThickness.average() returns a new ZThickness object rather than a NumPy array
 - This is now in keeping with SCC.weighted_average() returning a new SCC object
 - Updated tests to reflect a ZThickness object is returned, and the results are stored in a NumPy array in the .z_thickness attribute.


PR Checklist
------------
 - [x] Tests added and passing?
 - [x] Docs added and building?
 - [x] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
