### PR TITLE
Minor fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ lipyphilic CHANGELOG
 
 0.6.1 (????-??-??)
 ------------------
+* PR#49 Add min_diff argument to transformations.center_membrane
 * PR#48 Add MDAnalysis badge to README and fix typos in the docs
 * PR#47 Fixed typos in docs 
 

--- a/src/lipyphilic/lib/neighbours.py
+++ b/src/lipyphilic/lib/neighbours.py
@@ -576,7 +576,7 @@ class Neighbours(base.AnalysisBase):
         largest_cluster_resindices = np.full(self.n_frames, fill_value=0, dtype=object)
 
         n_residues = self.membrane.n_residues
-        for frame_index, frame in enumerate(self.frames):
+        for frame_index, frame in tqdm(enumerate(self.frames), total=self.n_frames):
             
             frame_filter = filter_by[:, frame_index]
             

--- a/src/lipyphilic/lib/z_positions.py
+++ b/src/lipyphilic/lib/z_positions.py
@@ -67,8 +67,8 @@ Note
 ----
 
 In the above example we are calculating the height of cholesterol in the bilayer, although
-the height of any molecule - even those not in the bilayer, such as peptides, - can be
-calculatd instea.
+the height of any molecule - even those not in the bilayer, such as peptides - can be
+calculated instead.
 
 
 We then select which frames of the trajectory to analyse (`None` will use every
@@ -146,8 +146,8 @@ class ZPositions(base.AnalysisBase):
         universe : Universe
             MDAnalysis Universe object
         lipid_sel : str
-            Selection string for the lipids in a membrane. The selection
-            should cover **all** residues in the membrane.
+            Selection string for the lipids in a membrane. Atoms in this selection are used
+            for calculating membrane midpoints.
         height_sel :  str
             Selection string for molecules for which the height in :math:`z` will be calculated.
             Any residues not in this selection will not have their :math:`z` positions calculated.
@@ -193,6 +193,7 @@ class ZPositions(base.AnalysisBase):
         
         # Atoms must be wrapped before creating a lateral grid of the membrane
         self.membrane.wrap(inplace=True)
+        self._height_atoms.wrap(inplace=True)
 
         # Find the midpoint of the bilayer as a function of (x,y), using
         # `n_bins` grid points in each dimensions
@@ -202,8 +203,6 @@ class ZPositions(base.AnalysisBase):
         else:
             # scipy.stats.binned_statistics raises Value error if there is only one bin
             bins = [0.0, self._ts.dimensions[0] + 1, self._ts.dimensions[0] + 2]
-        
-        self._height_atoms
         
         memb_midpoint_xy = scipy.stats.binned_statistic_2d(
             x=self.membrane.positions[:, 0],

--- a/src/lipyphilic/transformations.py
+++ b/src/lipyphilic/transformations.py
@@ -304,9 +304,8 @@ class center_membrane:
             *must* be smaller than the thickness of your bilayer or the diameter
             of your micelle.
         min_diff : float, optional
-            Minimum difference between peak-to-peak membrane thickness and the box
-            size. in a given dimension, in order for the membrane to be considered
-            unwrapped in this dimension.
+            Minimum difference between the peak-to-peak membrane thickness and the box
+            size in order for the membrane to be considered unwrapped.
         center_x : bool, optional
             If true, the membrane will be iteratively shifted in x until it is
             not longer split across periodic boundaries.


### PR DESCRIPTION
Changes made in this Pull Request:
 - Add progress bar to `lipyphilic.lib.Neighbours.largest_cluster`
 - Fix typos in docstrings
 - Add `min_diff` argument to `lipyphilic.transformations.center_membrane`. This sets the minimum difference required between the peak-to-peak distance of a membrane and the box length in order for the membrane to be considered whole.

