### PR TITLE
Improve performance of lipyphilic.lib.neighbours.Neighbours

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 lipyphilic CHANGELOG
 ====================
 
+0.6.2 (????-??-??)
+------------------
+* PR#52 Improved performance of lipyphilic.lib.neighbours.Neighbours (Fixes #51)
+
 0.6.1 (2021-04-16)
 ------------------
 * PR#49 Add min_diff argument to transformations.center_membrane

--- a/src/lipyphilic/lib/neighbours.py
+++ b/src/lipyphilic/lib/neighbours.py
@@ -37,7 +37,7 @@ Output
   - *neighbours* : a sparse matrix of binary variables, equal to 1 if two lipids are in contact, and 0 otherwise
 
 For efficient use of memory, an adjacency matrix of neighbouring lipids is stored
-in a :class:`scipy.sparse.csc_matrix` sparse matrix for each frame of the analysis. The data
+in a :class:`scipy.sparse.csr_matrix` sparse matrix for each frame of the analysis. The data
 are stored in the :attr:`neighbours.neighbours` attribute as a NumPy array of sparse
 matrices. Each matrix has shape (n_residues, n_residues)
 
@@ -82,7 +82,7 @@ frame) and select to display a progress bar (`verbose=True`)::
   )
   
 The results are then available in the :attr:`neighbours.Neighbours` attribute as a
-:class:`numpy.ndarray` of Compressed Sparse Column matrices.
+:class:`numpy.ndarray` of Compressed Sparse Row matrices.
 
 Counting the number of neighbours: by lipid species
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -307,7 +307,7 @@ class Neighbours(base.AnalysisBase):
         
         # store neighbours for this frame
         data = np.ones_like(ref)
-        self.neighbours[self._frame_index] = scipy.sparse.csc_matrix(
+        self.neighbours[self._frame_index] = scipy.sparse.csr_matrix(
             (data, (ref, neigh)),
             dtype=np.int8,
             shape=(self.membrane.n_residues, self.membrane.n_residues)
@@ -564,7 +564,7 @@ class Neighbours(base.AnalysisBase):
         for frame_index, neighbours in tqdm(enumerate(self.neighbours), total=self.n_frames):
             
             frame_filter = filter_by[:, frame_index]
-            frame_neighbours = neighbours.toarray()[frame_filter][:, frame_filter]
+            frame_neighbours = neighbours[frame_filter][:, frame_filter]
             
             # find all connected components
             _, com_labels = scipy.sparse.csgraph.connected_components(frame_neighbours)

--- a/src/lipyphilic/lib/neighbours.py
+++ b/src/lipyphilic/lib/neighbours.py
@@ -38,19 +38,13 @@ Output
 
 For efficient use of memory, an adjacency matrix of neighbouring lipids is stored
 in a :class:`scipy.sparse.csc_matrix` sparse matrix for each frame of the analysis. The data
-are stored in the :attr:`neighbours.neighbours` attribute. The matrix has shape
-(n_residues, n_residues * n_frames), and the data for frame *n* is accessed via::
-
-  neighbours.neighbours[:, (n * n_residues):((n + 1) * n_residues)]
-
-A matrix element *[i, j]* is equal to 1 if lipid *i* neighbours lipid *j* and equal to 0 otherwise.
-The matrix is symmetric: if lipid *i* neighbours lipid *j* then *j* must neighbour *i*.
-
+are stored in the :attr:`neighbours.neighbours` attribute as a NumPy array of sparse
+matrices. Each matrix has shape (n_residues, n_residues)
 
 Tip
 ---
 
-The resultant sparse matrix can be used to calculate the loca lipid composition of each individual lipid
+The resultant sparse matrix can be used to calculate the local lipid composition of each individual lipid
 at each frame using :func:`lipyphilic.lib.neighbours.count_neighbours`, or to find the largest cluster of
 lipids at each frame using :func:`lipyphilic.lib.neighbours.largest_cluster`.
 
@@ -88,7 +82,7 @@ frame) and select to display a progress bar (`verbose=True`)::
   )
   
 The results are then available in the :attr:`neighbours.Neighbours` attribute as a
-:class:`scipy.sparse.csc_matrix`.
+:class:`numpy.ndarray` of Compressed Sparse Column matrices.
 
 Counting the number of neighbours: by lipid species
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/lipyphilic/lib/test_neighbours.py
+++ b/tests/lipyphilic/lib/test_neighbours.py
@@ -29,12 +29,14 @@ class TestNeighbours:
         # it's a hexagonal lattice
         # with cutoff=12, every lipid should have 6 neighbours
         reference = {
+            'n_frames': 1,
             'n_residues': 100,  # there are 200 atoms but 100 lipids in total
             'n_neighbours': 6,
         }
     
-        assert neighbours.neighbours.shape == (reference['n_residues'], reference['n_residues'])
-        assert (np.sum(neighbours.neighbours.toarray(), axis=0) == reference['n_neighbours']).all()
+        assert neighbours.neighbours.shape[0] == (reference['n_frames'])
+        assert neighbours.neighbours[0].shape == (reference['n_residues'], reference['n_residues'])
+        assert (np.sum(neighbours.neighbours[0].toarray(), axis=0) == reference['n_neighbours']).all()
         
     def test_neighbours_cutoff10(self, universe):
         
@@ -44,12 +46,14 @@ class TestNeighbours:
         # it's a hexagonal lattice, but each hexagon is irregular (two sides longer than the other 4)
         # with cutoff=10, every lipid should have 2 neighbours
         reference = {
+            'n_frames': 1,
             'n_residues': 100,  # there are 200 atoms but 100 lipids in total
             'n_neighbours': 2,
         }
     
-        assert neighbours.neighbours.shape == (reference['n_residues'], reference['n_residues'])
-        assert (np.sum(neighbours.neighbours.toarray(), axis=0) == reference['n_neighbours']).all()
+        assert neighbours.neighbours.shape[0] == (reference['n_frames'])
+        assert neighbours.neighbours[0].shape == (reference['n_residues'], reference['n_residues'])
+        assert (np.sum(neighbours.neighbours[0].toarray(), axis=0) == reference['n_neighbours']).all()
         
     def test_subset_lipids(self, universe):
         
@@ -59,6 +63,7 @@ class TestNeighbours:
         # it's a hexagonal lattice, but each hexagon is irregular (two sides longer than the other 4)
         # with cutoff=10, every lipid should have 2 neighbours
         reference = {
+            'n_frames': 1,
             'n_residues': 50,
             'n_neighbours': np.array(
                 [
@@ -70,9 +75,10 @@ class TestNeighbours:
                 ]
             )
         }
-    
-        assert neighbours.neighbours.shape == (reference['n_residues'], reference['n_residues'])
-        assert_array_equal(np.sum(neighbours.neighbours.toarray(), axis=0), reference['n_neighbours'])
+        
+        assert neighbours.neighbours.shape[0] == (reference['n_frames'])
+        assert neighbours.neighbours[0].shape == (reference['n_residues'], reference['n_residues'])
+        assert_array_equal(np.sum(neighbours.neighbours[0].toarray(), axis=0), reference['n_neighbours'])
 
 
 class TestNeighboursExceptions:


### PR DESCRIPTION
Fixes #51 

Changes made in this Pull Request:
 - `lipyphilic.lib.neighbours.Neighbours` now stores results as a NumPy array of SciPy csc matrices
 - For large systems/trajectories, this becomes significantly faster than using a single list-of-lists matrix for the entire analysis
 - Test and documentation updated to reflect the change in format of the results

PR Checklist
------------
 - [x] Tests added and passing?
 - [x] Docs added and building?
 - [x] CHANGELOG updated?
 - [x] AUTHORS updated if necessary?
 - [x] Issue raised and referenced?
