### PR TITLE
Improve FlipFLop performance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ lipyphilic CHANGELOG
 
 0.6.2 (????-??-??)
 ------------------
+* PR#53 Improved performance of lipyphilic.lib.flip_flop.FlipFlop
 * PR#52 Improved performance of lipyphilic.lib.neighbours.Neighbours (Fixes #51)
 
 0.6.1 (2021-04-16)

--- a/src/lipyphilic/lib/flip_flop.py
+++ b/src/lipyphilic/lib/flip_flop.py
@@ -237,7 +237,7 @@ class FlipFlop(base.AnalysisBase):
                              )
         
         self.n_frames = n_frames
-        self.frames = np.array([ts.frame for ts in trajectory[start:stop:step]], dtype=int)
+        self.frames = np.arange(start, stop, step)
           
     def _prepare(self):
         


### PR DESCRIPTION
Changes made in this Pull Request:
 - Inside `FlipFlop._setup_frames`, `FlipFlop.frames` is now created using `np.arange` rather than by iterating over the trajectory
 - For long trajectories this provides a large performance boost


PR Checklist
------------
 - [x] Tests added and passing?
 - [x] Docs added and building?
 - [x] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
