### PR TITLE
Typos in docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ lipyphilic CHANGELOG
 
 0.6.2 (????-??-??)
 ------------------
+* PR#54 Fixed typos in docs 
 * PR#53 Improved performance of lipyphilic.lib.flip_flop.FlipFlop
 * PR#52 Improved performance of lipyphilic.lib.neighbours.Neighbours (Fixes #51)
 

--- a/src/lipyphilic/lib/order_parameter.py
+++ b/src/lipyphilic/lib/order_parameter.py
@@ -19,7 +19,7 @@ of lipid tails in a bilayer.
 Coarse-grained order parameter
 ------------------------------
 
-The class :class:`liyphilic.lib.order_parameter.SCC` calculates the coarse=grained
+The class :class:`liyphilic.lib.order_parameter.SCC` calculates the coarse-grained
 order parameter, as defined in
 `Seo et al. (2020) <https://pubs.acs.org/doi/full/10.1021/acs.jpclett.0c01317>`__.
 The coarse-grained order parameter, :math:`S_{CC}`, is defined as:
@@ -176,7 +176,7 @@ from lipyphilic.lib.plotting import ProjectionPlot
 
 
 class SCC(base.AnalysisBase):
-    """Calculate coarse-grained acyl tail ordere parameter.
+    """Calculate coarse-grained acyl tail order parameter.
     """
 
     def __init__(self, universe,


### PR DESCRIPTION
Changes made in this Pull Request:
 - Fixed typos in `lipyphilic.lib.order_parameter` docs
