### PR TITLE
Scc weighted average

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ LiPyphilic CHANGELOG
 
 0.6.3 (????-??-??)
 ------------------
+* PR#59 Ensure SCC.weighted_average can handle different sized sn1 and sn2 residue groups.
 * PR#56 Update docs
 
 0.6.2 (2021-04-18)

--- a/src/lipyphilic/lib/order_parameter.py
+++ b/src/lipyphilic/lib/order_parameter.py
@@ -295,7 +295,7 @@ class SCC(base.AnalysisBase):
         
         scc = np.zeros((n_residues, sn1_scc.n_frames))
         
-        for species in np.unique([sn1_scc.tails.resnames, sn2_scc.tails.resnames]):
+        for species in np.unique(np.hstack([sn1_scc.tails.resnames, sn2_scc.tails.resnames])):
             
             if species not in sn1_scc.tails.resnames:
                 

--- a/tests/lipyphilic/lib/test_order_parameter.py
+++ b/tests/lipyphilic/lib/test_order_parameter.py
@@ -67,7 +67,7 @@ class TestSCCWeightedAverage:
     
     @pytest.fixture(scope='class')
     def sn1_scc(self, universe):
-        sn1_scc = SCC(universe, "name L")
+        sn1_scc = SCC(universe, "name L C")
         sn1_scc.run()
         return sn1_scc
     
@@ -82,9 +82,9 @@ class TestSCCWeightedAverage:
         scc = SCC.weighted_average(sn1_scc, sn1_scc)
         
         reference = {
-            'n_residues': 50,
+            'n_residues': 100,
             'n_frames': 1,
-            'scc': np.full((50, 1), fill_value=-0.5)  # all bonds are perpendicular to the z-axis
+            'scc': np.full((100, 1), fill_value=-0.5)  # all bonds are perpendicular to the z-axis
         }
 
         assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
@@ -103,19 +103,6 @@ class TestSCCWeightedAverage:
         assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
         assert_array_almost_equal(scc.SCC, reference['scc'])
         
-    def test_SCC_weighted_average_indices(self, sn1_scc, sn2_scc):
-        
-        scc = SCC.weighted_average(sn1_scc, sn2_scc)
-        
-        reference = {
-            'n_residues': 100,
-            'n_frames': 1,
-            'scc': np.full((100, 1), fill_value=-0.5),  # all bonds are perpendicular to the z-axis
-        }
-
-        assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
-        assert_array_almost_equal(scc.SCC, reference['scc'])
-
 
 class TestSCCExceptions:
     

--- a/tests/lipyphilic/lib/test_order_parameter.py
+++ b/tests/lipyphilic/lib/test_order_parameter.py
@@ -67,31 +67,27 @@ class TestSCCWeightedAverage:
     
     @pytest.fixture(scope='class')
     def sn1_scc(self, universe):
-        sn1_scc = SCC(universe, "name L C")
+        sn1_scc = SCC(universe, "name C")
         sn1_scc.run()
         return sn1_scc
-    
-    @pytest.fixture(scope='class')
-    def sn2_scc(self, universe):
-        sn2_scc = SCC(universe, "name C")
-        sn2_scc.run()
-        return sn2_scc
     
     def test_SCC_weighted_average(self, sn1_scc):
         
         scc = SCC.weighted_average(sn1_scc, sn1_scc)
         
         reference = {
-            'n_residues': 100,
+            'n_residues': 50,
             'n_frames': 1,
-            'scc': np.full((100, 1), fill_value=-0.5)  # all bonds are perpendicular to the z-axis
+            'scc': np.full((50, 1), fill_value=-0.5)  # all bonds are perpendicular to the z-axis
         }
 
         assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
         assert_array_almost_equal(scc.SCC, reference['scc'])
         
-    def test_SCC_weighted_average_different_tails(self, sn1_scc, sn2_scc):
+    def test_SCC_weighted_average_different_tails(self, universe, sn1_scc):
         
+        sn2_scc = SCC(universe, "name L")
+        sn2_scc.run()
         scc = SCC.weighted_average(sn1_scc, sn2_scc)
         
         reference = {
@@ -102,7 +98,22 @@ class TestSCCWeightedAverage:
 
         assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
         assert_array_almost_equal(scc.SCC, reference['scc'])
+
+    def test_SCC_weighted_average_different_number_of_lipids(self, universe, sn1_scc):
         
+        sn2_scc = SCC(universe, "name L C")
+        sn2_scc.run()
+        scc = SCC.weighted_average(sn1_scc, sn2_scc)
+        
+        reference = {
+            'n_residues': 100,
+            'n_frames': 1,
+            'scc': np.full((100, 1), fill_value=-0.5)  # all bonds are perpendicular to the z-axis
+        }
+
+        assert scc.SCC.shape == (reference['n_residues'], reference['n_frames'])
+        assert_array_almost_equal(scc.SCC, reference['scc'])
+
 
 class TestSCCExceptions:
     


### PR DESCRIPTION
Changes made in this Pull Request:
 - Previously, `lipyphilic.lib.order_parameter.SCC.weighted_average` would fail if the sn1 and sn2 `SCC` objects had differing numbers of lipids
 - This has now been fixed and a test added that would previously fail but now passes


PR Checklis
------------
 - [x] Tests added and passing?
 - [x] Docs added and building?
 - [x] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
