### PR TITLE
Add abstact base class for leaflet analysis

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ LiPyphilic CHANGELOG
 
 0.6.3 (????-??-??)
 ------------------
+* PR#60 AssignLeaflets and AssignCurvedLeaflets inherit from shared leaflet analysis base class
 * PR#59 Ensure SCC.weighted_average can handle different sized sn1 and sn2 residue groups.
 * PR#56 Update docs
 


### PR DESCRIPTION
Changes made in this Pull Request:

* Both `AssignLeaflets` and `AssignCurvedLeaflets` now inherit from a shared base class (`AssignLeafletsBase`)

* Eventually, there should be a single `AssignLeaflets` class that will switch between using either the current `AssignLeaflets` approach or the `AssignCurvedLeaflets` approach depending on the arguments passed.

PR Checklist
------------
 - [ ] Tests added and passing?
 - [x] Docs added and building?
 - [x] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
