### PR TITLE
Change lagtimes from ps to ns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 LiPyphilic CHANGELOG
 ====================
 
+0.7.0 (????-??-??)
+------------------
+* PR#69 Change MSD lagtimes to be in ns rather than ps. Fix nojump unwrapping for the first frame.
+
 0.6.3 (2021-05-09)
 ------------------
 * PR#60 AssignLeaflets and AssignCurvedLeaflets inherit from shared leaflet analysis base class

--- a/src/lipyphilic/lib/lateral_diffusion.py
+++ b/src/lipyphilic/lib/lateral_diffusion.py
@@ -84,7 +84,7 @@ we can calculate the MSD of each lipid as follows::
 We then select which frames of the trajectory to analyse (`None` will use every
 frame) and choose to display a progress bar (`verbose=True`)::
   
-  leaflets.run(
+  msd.run(
     start=None,
     stop=None,
     step=None,
@@ -149,7 +149,7 @@ stop the linear fit::
 This will calculate a diffusion coefficient for each individual lipid and return the mean
 and standard error of the distribution of coefficients.
 
-To calculate the diffusion coefficient of a subset of lipids we can use the :attr:lipid_sel``
+To calculate the diffusion coefficient of a subset of lipids we can use the `:attr:lipid_sel`
 keyword::
 
   d, sem = msd.diffusion_coefficient(
@@ -184,8 +184,7 @@ class MSD(base.AnalysisBase):
                  lipid_sel,
                  com_removal_sel=None,
                  dt=None):
-        """Set up parameters for assigning lipids to a leaflet.
-
+        """
         Parameters
         ----------
         universe : Universe

--- a/src/lipyphilic/lib/lateral_diffusion.py
+++ b/src/lipyphilic/lib/lateral_diffusion.py
@@ -245,6 +245,10 @@ class MSD(base.AnalysisBase):
         
         self.lagtimes = self.frames * self.dt
         
+        # lagtimes must start from zero, and should be in ns
+        self.lagtimes -= self.lagtimes[0]
+        self.lagtimes /= 1000
+        
         for lipid_index in range(self.membrane.n_residues):
             
             self.msd[lipid_index] = tidynamics.msd(self.lipid_com_pos[lipid_index])

--- a/src/lipyphilic/transformations.py
+++ b/src/lipyphilic/transformations.py
@@ -198,7 +198,7 @@ class nojump:
             crossed_pbc = np.nonzero(diff[:, dim] > self.ag.universe.dimensions[dim] / 2)[0]
             self.translate[crossed_pbc, :, index] += self.ag.universe.dimensions[dim]
             
-            # Atoms that moved across the negative direction will have a large positive diff
+            # Atoms that moved across the positive direction will have a large negative diff
             crossed_pbc = np.nonzero(diff[:, dim] < -self.ag.universe.dimensions[dim] / 2)[0]
             self.translate[crossed_pbc, :, index] -= self.ag.universe.dimensions[dim]
         
@@ -214,7 +214,7 @@ class nojump:
                 crossed_pbc = np.nonzero(diff[:, dim] > ts.dimensions[dim] / 2)[0]
                 self.translate[crossed_pbc, ts.frame:, index] += ts.dimensions[dim]
 
-                # Atoms that moved across the negative direction will have a large positive diff
+                # Atoms that moved across the positive direction will have a large negative diff
                 crossed_pbc = np.nonzero(diff[:, dim] < -ts.dimensions[dim] / 2)[0]
                 self.translate[crossed_pbc, ts.frame:, index] -= ts.dimensions[dim]
         
@@ -237,7 +237,7 @@ class nojump:
                 crossed_pbc = np.nonzero(diff[:, dim] > self.ag.universe.dimensions[dim] / 2)[0]
                 self.translate[crossed_pbc, index] += self.ag.universe.dimensions[dim]
                 
-                # Atoms that moved across the negative direction will have a large positive diff
+                # Atoms that moved across the positive direction will have a large negative diff
                 crossed_pbc = np.nonzero(diff[:, dim] < -self.ag.universe.dimensions[dim] / 2)[0]
                 self.translate[crossed_pbc, index] -= self.ag.universe.dimensions[dim]
             
@@ -255,7 +255,7 @@ class nojump:
                     crossed_pbc = np.nonzero(diff[:, dim] > ts.dimensions[dim] / 2)[0]
                     self.translate[crossed_pbc, index] += ts.dimensions[dim]
 
-                    # Atoms that moved across the negative direction will have a large positive diff
+                    # Atoms that moved across the positive direction will have a large negative diff
                     crossed_pbc = np.nonzero(diff[:, dim] < -ts.dimensions[dim] / 2)[0]
                     self.translate[crossed_pbc, index] -= ts.dimensions[dim]
             

--- a/src/lipyphilic/transformations.py
+++ b/src/lipyphilic/transformations.py
@@ -140,6 +140,10 @@ class nojump:
         trajectory or a large number of atoms to be unwrapped, you can write the unwrapped coordinates
         to a new file by providing a :attr:`fileanme` to :class:`nojump`.
         
+        Warning
+        -------
+        The current implementation of `nojump` can only unwrap coordinates in orthorhombic systems.
+        
         """
         self.ag = ag
         self.nojump_xyz = np.array([nojump_x, nojump_y, nojump_z], dtype=bool)
@@ -195,7 +199,7 @@ class nojump:
             self.translate[crossed_pbc, :, index] += self.ag.universe.dimensions[dim]
             
             # Atoms that moved across the negative direction will have a large positive diff
-            crossed_pbc = np.nonzero(diff[:, dim] < self.ag.universe.dimensions[dim] / 2)[0]
+            crossed_pbc = np.nonzero(diff[:, dim] < -self.ag.universe.dimensions[dim] / 2)[0]
             self.translate[crossed_pbc, :, index] -= self.ag.universe.dimensions[dim]
         
         self.ref_pos = self.ag.positions
@@ -234,7 +238,7 @@ class nojump:
                 self.translate[crossed_pbc, index] += self.ag.universe.dimensions[dim]
                 
                 # Atoms that moved across the negative direction will have a large positive diff
-                crossed_pbc = np.nonzero(diff[:, dim] < self.ag.universe.dimensions[dim] / 2)[0]
+                crossed_pbc = np.nonzero(diff[:, dim] < -self.ag.universe.dimensions[dim] / 2)[0]
                 self.translate[crossed_pbc, index] -= self.ag.universe.dimensions[dim]
             
             self.ref_pos = self.ag.positions

--- a/tests/lipyphilic/lib/test_lateral_diffusion.py
+++ b/tests/lipyphilic/lib/test_lateral_diffusion.py
@@ -30,7 +30,7 @@ class TestMSD:
             'n_residues': 1,
             'n_frames': 2,
             'msd': [[0.0, 0.04394855]],
-            'lagtimes': [0.0, 5000.0]
+            'lagtimes': [0.0, 5.0]
         }
         
         assert msd.msd.shape == (reference['n_residues'], reference['n_frames'])
@@ -46,7 +46,7 @@ class TestMSD:
             'n_residues': 1,
             'n_frames': 2,
             'msd': [[0.0, 0.0]],
-            'lagtimes': [0.0, 5000.0]
+            'lagtimes': [0.0, 5.0]
         }
         
         assert msd.msd.shape == (reference['n_residues'], reference['n_frames'])


### PR DESCRIPTION
Changes made in this Pull Request:
 - `lipyphilic.lib.lateral_diffusion.msd.lagtimes` are now in ns rather than ps
 - typos fixed in docstrings and comments
 - fixed `lipyphilic.transformations.nojump` - the unwrapping was incorrect for the first frame. The check `dx < length_x/2` should be `dx < -length_x/2`

PR Checklist
------------
 - [x] Tests added and passing?
 - [x] Docs added and building?
 - [ ] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
