### PR TITLE
Tri to ortho

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 LiPyphilic CHANGELOG
 ====================
 
+0.8.0 (2021-07-31)
+* PR#74 Add the triclinic_to_orthorhombic transformation in order to support analysis of triclinic systems
+
 0.7.0 (2021-07-03)
 ------------------
 * PR#70 Remove support for Python 3.6

--- a/README.rst
+++ b/README.rst
@@ -74,22 +74,27 @@ The analysis classes are designed with the same interface as those of MDAnalysis
 will be a breeze.
  
 Analysis tools in **lipyphilic** include: identifying sterol flip-flop events, calculating domain registration over time,
-and calculating local lipid compositions. **lipyphilic** also has two on-the-fly trajectory transformations to i) fix
-membranes split across periodic boundaries and ii) perform nojump coordinate unwrapping. These tools position **lipyphilic**
-as complementary to, rather than competing against, existing membrane analysis software such as
-`MemSurfer <https://github.com/LLNL/MemSurfer>`__ and `FatSlim <http://fatslim.github.io/>`__.
+and calculating local lipid compositions. **lipyphilic** also has three on-the-fly trajectory transformations to i) fix
+membranes split across periodic boundaries and ii) perform nojump coordinate unwrapping and iii) convert triclinic coordinates
+to their orthorhombic representation.
 
-Check out the `Basic Usage <https://lipyphilic.readthedocs.io/en/stable/usage.html>`__ example to see how to use
-**lipyphilic**, and see the `Analysis tools <https://lipyphilic.readthedocs.io/en/stable/reference/analyses.html>`__ 
-section for detailed information and exmaples on each tool.
+These tools position **lipyphilic** as complementary to, rather than competing against, existing membrane analysis
+software such as `MemSurfer <https://github.com/LLNL/MemSurfer>`__ and `FatSlim <http://fatslim.github.io/>`__.
 
 Interactive tutorials
 =====================
 
-Check out our interactive tutorials on how to get the most out of **lipyphilic** 
-
 .. image:: https://mybinder.org/badge_logo.svg
  :target: https://mybinder.org/v2/gh/p-j-smith/lipyphilic-tutorials/main?filepath=notebooks%2F1-Introduction.ipynb
+
+We recommend new users take a look out our interactive tutorials. These will show you how to get the most out of **lipyphilic** 
+
+Basic Usage
+===========
+
+Alternatively, check out the `Basic Usage <https://lipyphilic.readthedocs.io/en/stable/usage.html>`__ example to see how to use
+**lipyphilic**, and see the `Analysis tools <https://lipyphilic.readthedocs.io/en/stable/reference/analyses.html>`__ 
+section for detailed information and examples on each tool.
 
 Installation
 ============
@@ -121,8 +126,8 @@ Full documentation
 Head to `lipyphilic.readthedocs.io <https://lipyphilic.readthedocs.io/en/stable/>`__, where you will find the full
 documentation of **lipyphilic**'s API as well as examples of how to use the analysis tools.
 
-Acknowlegment
-=============
+Acknowledgement
+===============
 
 The respository structure of **lipyphilic** is based on the
 `PyLibrary Cookeicutter template <https://github.com/ionelmc/cookiecutter-pylibrary>`__.

--- a/docs/reference/analyses.rst
+++ b/docs/reference/analyses.rst
@@ -433,10 +433,14 @@ On-the-fly transformations :mod:`lipyphilic.transformations`
 `lipyphilic` contains a module for applying on-the-fly transofrmation to atomic coordinates
 while iterating over a trajectory. These are availbale in the module :mod:`lipyphilic.transformations`.
 
-There are two transformations available in `lipyphilic`:
+There are three transformations available in `lipyphilic`:
 
-1. :class:`lipyphilic.transformations.nojump`, which prevents atoms from jumping across periodic boundaries. This is useful when calculating the lateral diffusion of lipids.
-2. :class:`lipyphilic.transformations.center_membrane`, which can take a membrane that is split across periodic boundaries, make it whole and center it in the box.
+1. | :class:`lipyphilic.transformations.nojump`, which prevents atoms from jumping across periodic
+   | boundaries. This is useful when calculating the lateral diffusion of lipids.
+2. | :class:`lipyphilic.transformations.center_membrane`, which can take a membrane that is split
+   | across periodic boundaries, make it whole and center it in the box.
+3. | :class:`lipyphilic.transformations.triclinic_to_orthorhombic`, which transforms triclinic coordinates
+   | into their orthorhombic representation.
 
 See :mod:`lipyphilic.transformations` for full details on these transformations including how to apply
 them to your trajectory.

--- a/src/lipyphilic/_simple_systems/pdbs/Triclinic-2Atoms.pdb
+++ b/src/lipyphilic/_simple_systems/pdbs/Triclinic-2Atoms.pdb
@@ -1,0 +1,5 @@
+TITLE     MDANALYSIS FRAME 0: Created by PDBWriter
+CRYST1  100.000  100.499  100.995  83.78  84.32  84.29 P 1           1
+ATOM      1  C   CHOLX   1      50.000  50.000  50.000  1.00  0.00           C
+ATOM      2  C   CHOLX   2     130.000 120.000 100.000  1.00  0.00           C
+END

--- a/src/lipyphilic/_simple_systems/pdbs/Triclinic-3Atoms.pdb
+++ b/src/lipyphilic/_simple_systems/pdbs/Triclinic-3Atoms.pdb
@@ -2,4 +2,5 @@ TITLE     MDANALYSIS FRAME 0: Created by PDBWriter
 CRYST1  100.000  100.499  100.995  83.78  84.32  84.29 P 1           1
 ATOM      1  C   CHOLX   1      50.000  50.000  50.000  1.00  0.00           C
 ATOM      2  C   CHOLX   2     130.000 120.000 100.000  1.00  0.00           C
+ATOM      3  C   CHOLX   3     -30.000 -20.000 -10.000  1.00  0.00           C
 END

--- a/src/lipyphilic/_simple_systems/simple_systems.py
+++ b/src/lipyphilic/_simple_systems/simple_systems.py
@@ -11,6 +11,7 @@ __all__ = [
     "HEX_LAT_OVERLAP",
     "ONE_CHOL",
     "ONE_CHOL_TRAJ",
+    "TRICLINIC"
 ]
 
 from pkg_resources import resource_filename
@@ -58,3 +59,8 @@ ONE_CHOL = resource_filename(__name__,
 # A trajectory of 25 frames of the above cholesterol molecule
 ONE_CHOL_TRAJ = resource_filename(__name__,
                                   "xtcs/Chol-Flip-Flop.xtc")
+
+# Triclinic system with two atoms
+# One atom is in the center of the box, the other outside the primary unit cell
+TRICLINIC = resource_filename(__name__,
+                             "pdbs/Triclinic-2Atoms.pdb")

--- a/src/lipyphilic/_simple_systems/simple_systems.py
+++ b/src/lipyphilic/_simple_systems/simple_systems.py
@@ -63,4 +63,4 @@ ONE_CHOL_TRAJ = resource_filename(__name__,
 # Triclinic system with three atoms
 # One atom is in the center of the box, the other two outside the primary unit cell
 TRICLINIC = resource_filename(__name__,
-                             "pdbs/Triclinic-3Atoms.pdb")
+                              "pdbs/Triclinic-3Atoms.pdb")

--- a/src/lipyphilic/_simple_systems/simple_systems.py
+++ b/src/lipyphilic/_simple_systems/simple_systems.py
@@ -60,7 +60,7 @@ ONE_CHOL = resource_filename(__name__,
 ONE_CHOL_TRAJ = resource_filename(__name__,
                                   "xtcs/Chol-Flip-Flop.xtc")
 
-# Triclinic system with two atoms
-# One atom is in the center of the box, the other outside the primary unit cell
+# Triclinic system with three atoms
+# One atom is in the center of the box, the other two outside the primary unit cell
 TRICLINIC = resource_filename(__name__,
-                             "pdbs/Triclinic-2Atoms.pdb")
+                             "pdbs/Triclinic-3Atoms.pdb")

--- a/src/lipyphilic/lib/area_per_lipid.py
+++ b/src/lipyphilic/lib/area_per_lipid.py
@@ -160,6 +160,12 @@ class AreaPerLipid(base.AnalysisBase):
         self.u = universe
         self.membrane = self.u.select_atoms(lipid_sel, updating=False)
         
+        if not np.allclose(self.u.dimensions[3:], 90.0):
+            raise ValueError("AreaPerLipid requires an orthorhombic box. Please use the on-the-fly "
+                             "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
+                             "before calling AreaPerLipid"
+                             )
+        
         if np.array(leaflets).ndim not in [1, 2]:
             raise ValueError("'leaflets' must either be a 1D array containing non-changing "
                              "leaflet ids of each lipid, or a 2D array of shape (n_residues, n_frames)"

--- a/src/lipyphilic/lib/assign_leaflets.py
+++ b/src/lipyphilic/lib/assign_leaflets.py
@@ -357,6 +357,12 @@ class AssignLeaflets(AssignLeafletsBase):
             midplane_sel=midplane_sel,
             midplane_cutoff=midplane_cutoff
         )
+        
+        if not np.allclose(self.u.dimensions[3:], 90.0):
+            raise ValueError("AssignLeaflets requires an orthorhombic box. Please use the on-the-fly "
+                             "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
+                             "before calling AssignLeaflets"
+                             )
 
         self.n_bins = n_bins
         self.leaflets = None

--- a/src/lipyphilic/lib/memb_thickness.py
+++ b/src/lipyphilic/lib/memb_thickness.py
@@ -190,6 +190,12 @@ class MembThickness(base.AnalysisBase):
         self.lipid_sel = lipid_sel if lipid_sel is not None else "all"
         self.membrane = self.u.select_atoms(self.lipid_sel, updating=False)
         
+        if not np.allclose(self.u.dimensions[3:], 90.0):
+            raise ValueError("MembThickness requires an orthorhombic box. Please use the on-the-fly "
+                             "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
+                             "before calling MembThickness"
+                             )
+        
         if np.array(leaflets).ndim not in [1, 2]:
             raise ValueError("'leaflets' must either be a 1D array containing non-changing "
                              "leaflet ids of each lipid, or a 2D array of shape (n_residues, n_frames)"

--- a/src/lipyphilic/lib/registration.py
+++ b/src/lipyphilic/lib/registration.py
@@ -258,6 +258,12 @@ class Registration(base.AnalysisBase):
         self.lower_sel = lower_sel
         self.membrane = self.u.select_atoms(f"({self.upper_sel}) or ({self.lower_sel})")
         
+        if not np.allclose(self.u.dimensions[3:], 90.0):
+            raise ValueError("Registration requires an orthorhombic box. Please use the on-the-fly "
+                             "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
+                             "before calling Registration"
+                             )
+        
         if np.array(leaflets).ndim not in [1, 2]:
             raise ValueError("'leaflets' must either be a 1D array containing non-changing "
                              "leaflet ids of each lipid, or a 2D array of shape (n_residues, n_frames)"

--- a/src/lipyphilic/lib/z_angles.py
+++ b/src/lipyphilic/lib/z_angles.py
@@ -137,6 +137,13 @@ class ZAngles(base.AnalysisBase):
         super(ZAngles, self).__init__(universe.trajectory)
 
         self.u = universe
+        
+        if not np.allclose(self.u.dimensions[3:], 90.0):
+            raise ValueError("ZAngles requires an orthorhombic box. Please use the on-the-fly "
+                             "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
+                             "before calling ZAngles"
+                            )
+        
         self.atom_A = self.u.select_atoms(atom_A_sel, updating=False)
         self.atom_B = self.u.select_atoms(atom_B_sel, updating=False)
         

--- a/src/lipyphilic/lib/z_angles.py
+++ b/src/lipyphilic/lib/z_angles.py
@@ -142,7 +142,7 @@ class ZAngles(base.AnalysisBase):
             raise ValueError("ZAngles requires an orthorhombic box. Please use the on-the-fly "
                              "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
                              "before calling ZAngles"
-                            )
+                             )
         
         self.atom_A = self.u.select_atoms(atom_A_sel, updating=False)
         self.atom_B = self.u.select_atoms(atom_B_sel, updating=False)

--- a/src/lipyphilic/lib/z_positions.py
+++ b/src/lipyphilic/lib/z_positions.py
@@ -173,7 +173,7 @@ class ZPositions(base.AnalysisBase):
             raise ValueError("ZPositions requires an orthorhombic box. Please use the on-the-fly "
                              "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
                              "before calling ZPositions"
-                            )
+                             )
             
         # lipid species for which the height in z will be calculated
         self._height_species = np.unique(self._height_atoms.resnames)

--- a/src/lipyphilic/lib/z_positions.py
+++ b/src/lipyphilic/lib/z_positions.py
@@ -168,6 +168,12 @@ class ZPositions(base.AnalysisBase):
         self.u = universe
         self.membrane = self.u.select_atoms(lipid_sel, updating=False)
         self._height_atoms = self.u.select_atoms(height_sel, updating=False)
+        
+        if not np.allclose(self.u.dimensions[3:], 90.0):
+            raise ValueError("ZPositions requires an orthorhombic box. Please use the on-the-fly "
+                             "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
+                             "before calling ZPositions"
+                            )
             
         # lipid species for which the height in z will be calculated
         self._height_species = np.unique(self._height_atoms.resnames)

--- a/src/lipyphilic/lib/z_thickness.py
+++ b/src/lipyphilic/lib/z_thickness.py
@@ -137,7 +137,7 @@ class ZThickness(base.AnalysisBase):
             raise ValueError("ZThickness requires an orthorhombic box. Please use the on-the-fly "
                              "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
                              "before calling ZThickness"
-                            )
+                             )
         
         # For fancy slicing of atoms for each species
         self.lipid_atom_mask = {species: self.lipids.resnames == species for species in np.unique(self.lipids.resnames)}

--- a/src/lipyphilic/lib/z_thickness.py
+++ b/src/lipyphilic/lib/z_thickness.py
@@ -133,6 +133,12 @@ class ZThickness(base.AnalysisBase):
         self.u = universe
         self.lipids = self.u.select_atoms(lipid_sel, updating=False)
         
+        if not np.allclose(self.u.dimensions[3:], 90.0):
+            raise ValueError("ZThickness requires an orthorhombic box. Please use the on-the-fly "
+                             "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
+                             "before calling ZThickness"
+                            )
+        
         # For fancy slicing of atoms for each species
         self.lipid_atom_mask = {species: self.lipids.resnames == species for species in np.unique(self.lipids.resnames)}
         

--- a/src/lipyphilic/transformations.py
+++ b/src/lipyphilic/transformations.py
@@ -189,6 +189,12 @@ class nojump:
         self.ag = ag
         self.nojump_xyz = np.array([nojump_x, nojump_y, nojump_z], dtype=bool)
         self._nojump_indices = self.nojump_xyz.nonzero()[0]
+        
+        if not np.allclose(self.ag.universe.dimensions[3:], 90.0):
+            raise ValueError("nojump requires an orthorhombic box. Please use the on-the-fly "
+                             "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
+                             "before calling nojump"
+                            )
 
         self.ref_pos = ag.positions
         
@@ -372,6 +378,12 @@ class center_membrane:
         self.center_xyz = np.array([center_x, center_y, center_z], dtype=bool)
         self.min_diff = min_diff
         
+        if not np.allclose(self.membrane.universe.dimensions[3:], 90.0):
+            raise ValueError("center_membrane requires an orthorhombic box. Please use the on-the-fly "
+                             "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
+                             "before calling center_membrane"
+                            )
+        
     def __call__(self, ts):
         """Fix a membrane split across periodic boundaries.
         """
@@ -466,7 +478,7 @@ class triclinic_to_orthorhombic:
         """
                 
         if not isinstance(self.atoms.universe.trajectory.transformations[0], triclinic_to_orthorhombic):
-            raise ValueError("No other transformation should be applied"
+            raise ValueError("No other transformation should be applied "
                             "before triclinic_to_orthorhombic"
                             )
         

--- a/src/lipyphilic/transformations.py
+++ b/src/lipyphilic/transformations.py
@@ -120,7 +120,7 @@ These analyses will fail with triclinic boxes - the `triclinic_to_orthorhombic` 
 
 Another case that will fail with triclinic systems is the :class:`lipyphilic.transformations.nojump`
 transformation -  this transformation can currently only unwrap coordinates for orthorhombic
-systems. 
+systems.
 
 .. autoclass:: nojump
 .. autoclass:: center_membrane
@@ -194,7 +194,7 @@ class nojump:
             raise ValueError("nojump requires an orthorhombic box. Please use the on-the-fly "
                              "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
                              "before calling nojump"
-                            )
+                             )
 
         self.ref_pos = ag.positions
         
@@ -382,7 +382,7 @@ class center_membrane:
             raise ValueError("center_membrane requires an orthorhombic box. Please use the on-the-fly "
                              "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
                              "before calling center_membrane"
-                            )
+                             )
         
     def __call__(self, ts):
         """Fix a membrane split across periodic boundaries.
@@ -468,7 +468,7 @@ class triclinic_to_orthorhombic:
             
         """
         
-        self.atoms = ag        
+        self.atoms = ag
         
     def __call__(self, ts):
         """Transform AtomGroup triclinic coordinates to orthorhombic.
@@ -479,8 +479,8 @@ class triclinic_to_orthorhombic:
                 
         if not isinstance(self.atoms.universe.trajectory.transformations[0], triclinic_to_orthorhombic):
             raise ValueError("No other transformation should be applied "
-                            "before triclinic_to_orthorhombic"
-                            )
+                             "before triclinic_to_orthorhombic"
+                             )
         
         positions = self.atoms.positions
         

--- a/src/lipyphilic/transformations.py
+++ b/src/lipyphilic/transformations.py
@@ -157,7 +157,7 @@ class nojump:
         Parameters
         ----------
         ag : AtomGroup
-            MDAnalysis AtomGroup containing *all* atoms in the membrane.
+            MDAnalysis AtomGroup to which to apply the transformation
         nojump_x : bool, optional
             If true, atoms will be prevented from jumping across periodic boundaries
             in the x dimension.
@@ -448,6 +448,12 @@ class triclinic_to_orthorhombic:
     
     def __init__(self, ag):
         """Check this is the first transformation to be applied.
+             
+        Parameters
+        ----------
+        ag : AtomGroup
+            MDAnalysis AtomGroup to which to apply the transformation
+            
         """
         
         if len(ag.universe.trajectory.transformations) != 0:

--- a/src/lipyphilic/transformations.py
+++ b/src/lipyphilic/transformations.py
@@ -81,6 +81,7 @@ Note
 
 `ag` should be an AtomGroup that contains *all* atoms in the membrane.
 
+
 Transform triclinic coordinates to their orthorhombic representation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -109,18 +110,13 @@ angles are all 90°. Further analysis may then be performed using the orthorhomb
 system.
 
 Some analyses in `lipyphilic` create a surface of the membrane plane using a two-dimensional
-rectangular grid. Currently, this includes:
+rectangular grid. This includes
 
   * :class:`lipyphilic.lib.assign_leaflet.AssignLeaflets`
   * :class:`lipyphilic.lib.memb_thickness.MembThicnkess`
   * :class:`lipyphilic.lib.registration.Registration`
 
-These analyses will fail with triclinic boxes - the `triclinic_to_orthorhombic` transformation
-*must* be applied to triclinic systems before these tools can be used.
-
-Another case that will fail with triclinic systems is the :class:`lipyphilic.transformations.nojump`
-transformation -  this transformation can currently only unwrap coordinates for orthorhombic
-systems.
+See :class:`lipyphilic.transformations.triclinic_to_orthorhombic` for the full list.
 
 .. autoclass:: nojump
 .. autoclass:: center_membrane
@@ -429,12 +425,17 @@ class triclinic_to_orthorhombic:
     """Transform triclinic coordinates to their orthorhombic representation.
     
     If you have a triclinic system, it is *essential* to apply this transformation before
-    using the following tools:
+    using the following analyses:
     
         * `lipyphilic.lib.assign_leaflet.AssignLeaflets`
+        * `lipyphilic.lib.area_per_lipid.AreaPerLipid`
         * `lipyphilic.lib.memb_thickness.MembThicnkess`
         * `lipyphilic.lib.registration.Registration`
+    
+    as well as before the following on-the-fly transformations:
+    
         * `lipyphilic.transformations.nojump`
+        * `lipyphilic.transformations.center_membrane`
     
     The above tools will fail unless provided with an orthorhombic system.
     
@@ -446,7 +447,7 @@ class triclinic_to_orthorhombic:
     Note
     ----
     
-    `triclinic_to_rectangular` will put all atoms into the primary (orthorhombic)
+    `triclinic_to_rectangular` will put all selected atoms into the primary (orthorhombic)
     unit cell - molecules will **not** be kept whole or unwrapped.
     
     Warning

--- a/src/lipyphilic/transformations.py
+++ b/src/lipyphilic/transformations.py
@@ -447,8 +447,8 @@ class triclinic_to_orthorhombic:
     """
     
     def __init__(self, ag):
-        """Check this is the first transformation to be applied.
-             
+        """
+          
         Parameters
         ----------
         ag : AtomGroup
@@ -456,12 +456,7 @@ class triclinic_to_orthorhombic:
             
         """
         
-        if len(ag.universe.trajectory.transformations) != 0:
-            raise ValueError("No other transformation should be applied"
-                            "before triclinic_to_orthorhombic"
-                            )
-        self.atoms = ag
-        
+        self.atoms = ag        
         
     def __call__(self, ts):
         """Transform AtomGroup triclinic coordinates to orthorhombic.
@@ -469,6 +464,11 @@ class triclinic_to_orthorhombic:
         This implementation is based on the GROMACS `trjconv -ur rect` code:
         https://github.com/gromacs/gromacs/blob/master/src/gromacs/pbcutil/pbc.cpp#L1401
         """
+                
+        if not isinstance(self.atoms.universe.trajectory.transformations[0], triclinic_to_orthorhombic):
+            raise ValueError("No other transformation should be applied"
+                            "before triclinic_to_orthorhombic"
+                            )
         
         positions = self.atoms.positions
         

--- a/tests/lipyphilic/lib/test_area_per_lipid.py
+++ b/tests/lipyphilic/lib/test_area_per_lipid.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_almost_equal
 from lipyphilic.lib.plotting import ProjectionPlot
 
 from lipyphilic._simple_systems.simple_systems import (
-    HEX_LAT, HEX_LAT_BUMP_MID_MOL, HEX_LAT_OVERLAP)
+    HEX_LAT, HEX_LAT_BUMP_MID_MOL, HEX_LAT_OVERLAP, TRICLINIC)
 from lipyphilic.lib.area_per_lipid import AreaPerLipid
 
 matplotlib.use("Agg")
@@ -152,6 +152,15 @@ class TestAreaPerLipidExceptions:
                 leaflets=np.array([[1, 1]] * 50 + [[-1, -1]] * 50)  # leaflets has two frames, apl one
             )
             areas.run()
+    
+        universe_triclinic = MDAnalysis.Universe(TRICLINIC)
+        match = "AreaPerLipid requires an orthorhombic box. Please use the on-the-fly"
+        with pytest.raises(ValueError, match=match):
+            areas = AreaPerLipid(
+                universe=universe_triclinic,
+                lipid_sel="name C",
+                leaflets=np.array([0, 0])
+            )
             
             
 class TestProjectArea:

--- a/tests/lipyphilic/lib/test_assign_leaflets.py
+++ b/tests/lipyphilic/lib/test_assign_leaflets.py
@@ -6,7 +6,7 @@ import MDAnalysis
 from numpy.testing import assert_array_equal
 
 from lipyphilic._simple_systems.simple_systems import (
-    HEX_LAT, HEX_LAT_BUMP, HEX_LAT_BUMP_MID_MOL, HEX_LAT_BUMP_MID_ATOM)
+    HEX_LAT, HEX_LAT_BUMP, HEX_LAT_BUMP_MID_MOL, HEX_LAT_BUMP_MID_ATOM, TRICLINIC)
 from lipyphilic.lib.assign_leaflets import AssignLeaflets, AssignCurvedLeaflets
  
  
@@ -112,6 +112,15 @@ class TestAssignLeafletsExceptions:
                 midplane_sel="name C",
                 midplane_cutoff=10
             )
+        
+        universe_triclinic = MDAnalysis.Universe(TRICLINIC)
+        match = "AssignLeaflets requires an orthorhombic box. Please use the on-the-fly"
+        with pytest.raises(ValueError, match=match):
+            AssignLeaflets(
+                universe=universe_triclinic,
+                lipid_sel="name C",
+            )
+
         
 
 class TestAssignLeafletsUndulating:

--- a/tests/lipyphilic/lib/test_assign_leaflets.py
+++ b/tests/lipyphilic/lib/test_assign_leaflets.py
@@ -121,7 +121,6 @@ class TestAssignLeafletsExceptions:
                 lipid_sel="name C",
             )
 
-        
 
 class TestAssignLeafletsUndulating:
     

--- a/tests/lipyphilic/lib/test_memb_thickness.py
+++ b/tests/lipyphilic/lib/test_memb_thickness.py
@@ -6,7 +6,7 @@ import MDAnalysis
 from numpy.testing import assert_array_equal
 
 from lipyphilic._simple_systems.simple_systems import (
-    HEX_LAT, HEX_LAT_BUMP)
+    HEX_LAT, HEX_LAT_BUMP, TRICLINIC)
 from lipyphilic.lib.memb_thickness import MembThickness
  
  
@@ -139,3 +139,12 @@ class TestMembThicknessExceptions:
                 leaflets=np.array([[1, 1]] * 50 + [[-1, -1]] * 50)  # leaflets has two frames, apl one
             )
             areas.run()
+        
+        universe_triclinic = MDAnalysis.Universe(TRICLINIC)
+        match = "MembThickness requires an orthorhombic box. Please use the on-the-fly"
+        with pytest.raises(ValueError, match=match):
+            MembThickness(
+                universe=universe_triclinic,
+                lipid_sel="name C",
+                leaflets=[0, 0],
+            )

--- a/tests/lipyphilic/lib/test_registration.py
+++ b/tests/lipyphilic/lib/test_registration.py
@@ -5,7 +5,7 @@ import MDAnalysis
 
 from numpy.testing import assert_array_almost_equal
 
-from lipyphilic._simple_systems.simple_systems import HEX_LAT
+from lipyphilic._simple_systems.simple_systems import HEX_LAT, TRICLINIC
 from lipyphilic.lib.registration import Registration
  
  
@@ -205,3 +205,14 @@ class TestRegistrationExceptions:
                 leaflets=self.kwargs['leaflets'],
                 filter_by=filter_by[:99]
             )
+        
+        universe_triclinic = MDAnalysis.Universe(TRICLINIC)
+        match = "Registration requires an orthorhombic box. Please use the on-the-fly"
+        with pytest.raises(ValueError, match=match):
+            Registration(
+                universe=universe_triclinic,
+                upper_sel="name C",
+                lower_sel="name C",
+                leaflets=[0, 0],
+            )
+        

--- a/tests/lipyphilic/lib/test_z_angles.py
+++ b/tests/lipyphilic/lib/test_z_angles.py
@@ -6,7 +6,7 @@ import MDAnalysis
 from numpy.testing._private.utils import assert_array_almost_equal
 
 from lipyphilic._simple_systems.simple_systems import (
-    ONE_CHOL, ONE_CHOL_TRAJ)
+    ONE_CHOL, ONE_CHOL_TRAJ, TRICLINIC)
 from lipyphilic.lib.z_angles import ZAngles
  
  
@@ -90,4 +90,13 @@ class TestZAnglesExceptions:
             ZAngles(
                 universe=universe,
                 **self.kwargs
+            )
+        
+        universe_triclinic = MDAnalysis.Universe(TRICLINIC)
+        match = "ZAngles requires an orthorhombic box. Please use the on-the-fly"
+        with pytest.raises(ValueError, match=match):
+            ZAngles(
+                universe=universe_triclinic,
+                atom_A_sel='name C',
+                atom_B_sel='name C',
             )

--- a/tests/lipyphilic/lib/test_z_positions.py
+++ b/tests/lipyphilic/lib/test_z_positions.py
@@ -53,7 +53,8 @@ class TestZPositions:
                 lipid_sel="name C",
                 height_sel="name C C"
             )
-        
+
+
 class TestZPositionsOneAtom:
     
     @staticmethod

--- a/tests/lipyphilic/lib/test_z_positions.py
+++ b/tests/lipyphilic/lib/test_z_positions.py
@@ -6,7 +6,7 @@ import MDAnalysis
 from numpy.testing import assert_array_equal
 
 from lipyphilic._simple_systems.simple_systems import (
-    HEX_LAT, HEX_LAT_BUMP)
+    HEX_LAT, HEX_LAT_BUMP, TRICLINIC)
 from lipyphilic.lib.z_positions import ZPositions
  
  
@@ -42,7 +42,17 @@ class TestZPositions:
         
         assert z_positions.z_positions.shape == (reference['n_residues'], reference['n_frames'])
         assert_array_equal(z_positions.z_positions, reference['z_positions'])
+    
+    def test_exceptions(self):
         
+        universe_triclinic = MDAnalysis.Universe(TRICLINIC)
+        match = "ZPositions requires an orthorhombic box. Please use the on-the-fly"
+        with pytest.raises(ValueError, match=match):
+            ZPositions(
+                universe=universe_triclinic,
+                lipid_sel="name C",
+                height_sel="name C C"
+            )
         
 class TestZPositionsOneAtom:
     

--- a/tests/lipyphilic/lib/test_z_thickness.py
+++ b/tests/lipyphilic/lib/test_z_thickness.py
@@ -5,7 +5,7 @@ import MDAnalysis
 
 from numpy.testing._private.utils import assert_array_almost_equal, assert_array_equal
 
-from lipyphilic._simple_systems.simple_systems import HEX_LAT_MONO
+from lipyphilic._simple_systems.simple_systems import HEX_LAT_MONO, TRICLINIC
 from lipyphilic.lib.z_thickness import ZThickness
  
  
@@ -118,3 +118,11 @@ class TestZThicknessAverageExceptions:
             sn2_thickness.run(stop=1)
             sn2_thickness.frames = np.array([10])
             ZThickness.average(sn1_thickness, sn2_thickness)
+    
+        universe_triclinic = MDAnalysis.Universe(TRICLINIC)
+        match = "ZThickness requires an orthorhombic box. Please use the on-the-fly"
+        with pytest.raises(ValueError, match=match):
+            ZThickness(
+                universe=universe_triclinic,
+                lipid_sel="name C",
+            )

--- a/tests/lipyphilic/test_transformations.py
+++ b/tests/lipyphilic/test_transformations.py
@@ -6,6 +6,8 @@ import MDAnalysis
 
 from numpy.testing import assert_almost_equal, assert_array_almost_equal, assert_raises
 
+import MDAnalysis.transformations.wrap
+
 from lipyphilic._simple_systems.simple_systems import (
     HEX_LAT_TRANS, HEX_LAT_TRANS_TRAJ, HEX_LAT_SPLIT_Z, TRICLINIC
 )
@@ -82,6 +84,16 @@ class TestNoJump:
         np.testing.assert_array_almost_equal(self.reference["x_diffs"], x_diffs, decimal=5)
         np.testing.assert_array_almost_equal(self.reference["y_diffs"], y_diffs, decimal=5)
         np.testing.assert_array_almost_equal(self.reference["z_diffs"], z_diffs, decimal=5)
+    
+    def test_exceptions(self):
+        
+        universe_triclinic = MDAnalysis.Universe(TRICLINIC)
+        
+        match = "nojump requires an orthorhombic box. Please use the on-the-fly"
+        with pytest.raises(ValueError, match=match):
+            universe_triclinic.trajectory.add_transformations(
+                nojump(ag=universe_triclinic.atoms)
+            )
 
  
 class TestNoJumpStatic:
@@ -195,6 +207,17 @@ class TestCenterMembrane:
         
         assert bilayer_height == self.reference["correct_bilayer_height"]
         assert bilayer_midpoint == self.reference["bilayer_midpoint"]
+    
+    def test_exceptions(self):
+        
+        universe_triclinic = MDAnalysis.Universe(TRICLINIC)
+        
+        match = "center_membrane requires an orthorhombic box. Please use the on-the-fly"
+        with pytest.raises(ValueError, match=match):
+            universe_triclinic.trajectory.add_transformations(
+                center_membrane(ag=universe_triclinic.atoms)
+            )
+
 
 
 class TestTriclinicToOrthorhombic:
@@ -240,9 +263,9 @@ class TestTriclinicToOrthorhombic:
         universe = MDAnalysis.Universe(TRICLINIC)
         atoms = universe.atoms
         
-        match = "No other transformation should be applied"
+        match = "No other transformation should be applied "
         with pytest.raises(ValueError, match=match):
             universe.trajectory.add_transformations(
-                nojump(ag=atoms),
+                MDAnalysis.transformations.wrap(ag=atoms),
                 triclinic_to_orthorhombic(ag=atoms)
             )

--- a/tests/lipyphilic/test_transformations.py
+++ b/tests/lipyphilic/test_transformations.py
@@ -219,7 +219,6 @@ class TestCenterMembrane:
             )
 
 
-
 class TestTriclinicToOrthorhombic:
     
     def test_no_transformation(self):

--- a/tests/lipyphilic/test_transformations.py
+++ b/tests/lipyphilic/test_transformations.py
@@ -205,14 +205,14 @@ class TestTriclinicToOrthorhombic:
         pos = universe.atoms.positions
         wrapped_pos = universe.atoms.wrap()
         
-        # Second atom is currently outside the unit cell
+        # Second and third atoms are currently outside the unit cell
         assert_raises(
             AssertionError,
             assert_array_almost_equal,
             pos, wrapped_pos, decimal=5
         )
     
-    def test_transform_frame(self, universe):
+    def test_transform_frame(self):
         
         universe = MDAnalysis.Universe(TRICLINIC)
         atoms = universe.atoms
@@ -224,7 +224,7 @@ class TestTriclinicToOrthorhombic:
         # Below distance calculated using `mda.lib.distances.distance_array`
         triclinic_dist = 65.57408
         
-        atom1_pos, atom2_pos = universe.atoms.positions
+        atom1_pos, atom2_pos, _ = universe.atoms.positions
         orthorhombic_dist = np.linalg.norm(atom1_pos - atom2_pos)
         
         assert_almost_equal(triclinic_dist, orthorhombic_dist, decimal=5)

--- a/tests/lipyphilic/test_transformations.py
+++ b/tests/lipyphilic/test_transformations.py
@@ -234,3 +234,15 @@ class TestTriclinicToOrthorhombic:
         wrapped_pos = universe.atoms.wrap()
         
         assert_array_almost_equal(pos, wrapped_pos, decimal=5)
+
+    def test_Exceptions(self):
+        
+        universe = MDAnalysis.Universe(TRICLINIC)
+        atoms = universe.atoms
+        
+        match = "No other transformation should be applied"
+        with pytest.raises(ValueError, match=match):
+            universe.trajectory.add_transformations(
+                nojump(ag=atoms),
+                triclinic_to_orthorhombic(ag=atoms)
+            )


### PR DESCRIPTION
Fixes #73 

Changes made in this Pull Request:
 - Some analyses in lipyphilic currently do not support triclinic systems
 - An on-the-fly transfomation to convert triclinic coordinates to their orthorhombic representation has been added. This will be the recommended way to analyse triclinic systems.

Edit:

The on the fly transformation is equivalent to using `gmx trjconv` with the flag `-ur rect`.

PR Checklist
------------
 - [x] Tests added and passing?
 - [x] Docs added and building?
 - [x] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [x] Issue raised and referenced?
