### PR TITLE
Switch from travis to github actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -32,6 +32,3 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
-
-[html]
-directory = coverage_html

--- a/.coveragerc
+++ b/.coveragerc
@@ -32,3 +32,6 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
+
+[html]
+directory = coverage_html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,6 @@ jobs:
       if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == 3.9 }}
       uses: codecov/codecov-action@v2
       with:
-        directory: ./coverage_html
+        directory: $HOME/coverage_html
         fail_ci_if_error: true
         verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Test and build
+
+on:
+  push:
+    branches: [ master ]  # run when anything is pushed to these branches
+  pull_request:
+    branches: [ master ]  # run for the code submitted as a PR to these branches
+
+# jobs are a series of steps which run commands in the chosen virtualized environment to perform some action
+jobs:
+  build:
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9, 3.10]
+
+    steps:
+
+    # first step checks out the code into 
+    - uses: actions/checkout@v2
+
+    # Setup Python using a existing action "actions/setup-python@v2" from Github's library of actions
+    # Arguments are provided to this action using the key-values under "with"
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    # Install the requirements for this library plus those for running our tests (flake8 and coverage)
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+
+    - name: Test with tox
+      run: tox
+      env:
+        PLATFORM: ${{ matrix.platform }}
+
+    # Using Codecov's action, upload the coverage report for the triggering commit/PR
+    - name: Upload coverage
+      uses: codecov/codecov-action@v2
+      with:
+        file: ./coverage.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 # jobs are a series of steps which run commands in the chosen virtualized environment to perform some action
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
@@ -35,11 +35,3 @@ jobs:
 
     - name: Test with tox
       run: tox
-      env:
-        PLATFORM: ${{ matrix.platform }}
-
-    # Using Codecov's action, upload the coverage report for the triggering commit/PR
-    - name: Upload coverage
-      uses: codecov/codecov-action@v2
-      with:
-        file: ./coverage.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,5 @@ jobs:
       uses: codecov/codecov-action@v2
       with:
         directory: ./coverage_html
+        fail_ci_if_error: true
+        verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
     # first step checks out the code into 
     - uses: actions/checkout@v2
 
+    # Check where conda is installed in the gh runner
+    - name: check conda
+      run: |
+        echo ${CONDA}
+        ${CONDA}/bin/conda --version
+
     # Setup Python using a existing action "actions/setup-python@v2" from Github's library of actions
     # Arguments are provided to this action using the key-values under "with"
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,6 @@ jobs:
     # first step checks out the code into 
     - uses: actions/checkout@v2
 
-    # Check where conda is installed in the gh runner
-    - name: check conda
-      run: |
-        echo ${CONDA}
-        ${CONDA}/bin/conda --version
-
     # Setup Python using a existing action "actions/setup-python@v2" from Github's library of actions
     # Arguments are provided to this action using the key-values under "with"
     - name: Set up Python ${{ matrix.python-version }}
@@ -33,7 +27,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    # Install the requirements for this library plus those for running our tests (flake8 and coverage)
+    # Install the requirements for this library plus those for running our tests
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,10 @@ jobs:
 
     - name: Test with tox
       run: tox
+
+    # Using Codecov's action, upload the coverage report for the triggering commit/PR
+    - name: Upload coverage
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == 3.9 }}
+      uses: codecov/codecov-action@v2
+      with:
+        directory: ./coverage_html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,6 @@ jobs:
       if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == 3.9 }}
       uses: codecov/codecov-action@v2
       with:
-        directory: $HOME/coverage_html
+        files: coverage.xml
         fail_ci_if_error: true
         verbose: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 LiPyphilic CHANGELOG
 ====================
 
+0.10.0 (????-??-??)
+* PR#86 Add option to SCC.project_SCC to not unwrap lipids before calculating their center of masses
+
 0.9.0 (2021-09-02)
 ------------------
 * PR#78 Min MDAnalysis version increased to 2.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ LiPyphilic CHANGELOG
 ====================
 
 0.10.0 (????-??-??)
+* PR88 Use GitHub Actions for running tests rather than Travis.
 * PR#86 Add option to SCC.project_SCC to not unwrap lipids before calculating their center of masses
 
 0.9.0 (2021-09-02)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ include CHANGELOG.rst
 include CONTRIBUTING.rst
 include LICENSE
 include README.rst
+include requirements-dev.txt
 include requirements.yml
 include requirements-dev.yml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools >= 40.0.4",
+    "setuptools_scm >= 2.0.0",
+    "wheel >= 0.29.0",
+]
+build-backend = 'setuptools.build_meta'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,13 @@
+numpy >=1.16
+scipy >=1.5
+pandas >=1.1.0
+mdanalysis >=2.0
+tidynamics
+freud-analysis >=2.4.1
+tidynamics
+seaborn>=0.11
+tqdm
+pytest
+pytest-cov
+coverage
+tox

--- a/requirements-dev.yml
+++ b/requirements-dev.yml
@@ -15,3 +15,6 @@ dependencies:
     - seaborn>=0.11
     - tqdm
     - pip
+    - pytest
+    - pytest-cov
+    - coverage

--- a/requirements-dev.yml
+++ b/requirements-dev.yml
@@ -12,6 +12,7 @@ dependencies:
     - mdanalysis >=2.0
     - freud >=2.4.1
     - tidynamics
+    - matplotlib>=3.5
     - seaborn>=0.11
     - tqdm
     - pip

--- a/src/lipyphilic/lib/plotting.py
+++ b/src/lipyphilic/lib/plotting.py
@@ -632,14 +632,15 @@ class JointDensity:
                     cbar_kws["label"] = "PMF"  # pragma: no cover # testing for this label works locally but fails with tox/Travis
                 else:
                     cbar_kws["label"] = "Probability density"
-                    
-            if "aspect" not in cbar_kws:
-                cbar_kws["aspect"] = 30
-                
+
             if "pad" not in cbar_kws:
                 cbar_kws["pad"] = 0.025
             
             self.cbar = self.fig.colorbar(self._imshow, **cbar_kws)
+            
+            # For some reason the aspect is not set by passing it as a keyword
+            aspect = cbar_kws["aspect"] if "aspect" in cbar_kws else 30
+            self.cbar.ax.set_aspect(aspect)
 
             ticks = self.cbar.get_ticks()
             labels = ticks.round(2).astype(str)

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,28 @@ envlist =
     clean,
     check,
     docs,
+    codecov,
     py37-cover,
     py38-cover,
     py39-cover,
-    py310-cover
-    radon
+    py310-cover,
+    radon,
     report
 ignore_basepython_conflict = true
+requires = tox-conda
+
+[gh-actions]
+python =
+    3.7: py37-cover
+    3.8: py38-cover, check, docs, codecov
+    3.9: py39-cover
+    3.10: py310-cover
+
+[gh-actions:env]
+PLATFORM =
+    ubuntu-latest: linux
+    macos-latest: macos
+    windows-latest: windows
 
 [flake8]
 ignore = E121,E123,E501,W293,W504,W605
@@ -28,7 +43,6 @@ passenv =
     *
 deps =
     pytest
-    pytest-travis-fold
     pytest-cov
     coverage
 conda_deps =
@@ -39,6 +53,8 @@ conda_deps =
 conda_channels =
     conda-forge
     defaults
+conda_env =
+    requirements-dev.yml
 commands =
     pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv {posargs}    
 
@@ -139,7 +155,7 @@ setenv =
     {[testenv]setenv}
 usedevelop = true
 commands =
-    pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv {posargs}    
+    pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv {posargs}
 deps =
     {[testenv]deps}
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ ignore_basepython_conflict = true
 [gh-actions]
 python =
     3.7: py37
-    3.8: py38, check, docs, codecov
-    3.9: py39
+    3.8: py38
+    3.9: py39, check, docs, codecov
 
 [flake8]
 ignore = E121,E123,E501,W293,W504,W605
@@ -82,7 +82,7 @@ setenv =
     {[testenv]setenv}
 usedevelop = true
 commands =
-    pytest --cov --cov-report=html:coverage_html --cov-append --cov-config=.coveragerc -vv {posargs}
+    pytest --cov --cov-report=html:{toxinidir}/coverage_html --cov-append --cov-config=.coveragerc -vv {posargs}
 deps =
     {[testenv]deps}
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,56 +1,42 @@
 [tox]
+isolated_build = true
 envlist =
     clean,
     check,
     docs,
     codecov,
-    py37-cover,
-    py38-cover,
-    py39-cover,
-    py310-cover,
     radon,
-    report
+    report,
+    py37,
+    py38,
+    py39,
+    py39-cover,
+    p310,
 ignore_basepython_conflict = true
 
 [gh-actions]
 python =
-    3.7: py37-cover
-    3.8: py38-cover, check, docs, codecov
-    3.9: py39-cover
-    3.10: py310-cover
-
-[gh-actions:env]
-PLATFORM =
-    ubuntu-latest: linux
-    macos-latest: macos
-    windows-latest: windows
+    3.7: py37
+    3.8: py38, check, docs, codecov
+    3.9: py39
+    3.10: py310
 
 [flake8]
 ignore = E121,E123,E501,W293,W504,W605
 
 [testenv]
-basepython =
-    {bootstrap,clean,check,report,docs,codecov}: {env:TOXPYTHON:python3}
-    {py37}: {env:TOXPYTHON:python3.7}
-    {py38,clean,check,docs,radon,report}: {env:TOXPYTHON:python3.8}
-    {py39,}: {env:TOXPYTHON:python3.9}
-    {py310,}: {env:TOXPYTHON:python3.10}
 setenv =
-    PYTHONPATH={toxinidir}/tests
+    PYTHONPATH = {toxinidir}/tests
     PYTHONUNBUFFERED=yes
-passenv =
-    *
-deps = -rrequirements.txt
-commands =
-    pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv {posargs}    
-
-[testenv:bootstrap]
 deps =
-    jinja2
-    matrix
-skip_install = true
+    -r{toxinidir}/requirements_dev.txt
 commands =
-    python ci/bootstrap.py --no-env
+    pytest --basetemp={envtmpdir} -vv {posargs}
+
+[testenv:clean]
+commands = coverage erase
+skip_install = true
+deps = coverage
 
 [testenv:check]
 deps =
@@ -59,20 +45,11 @@ deps =
     flake8
     readme-renderer
     pygments
-    #isort
 skip_install = true
 commands =
     python setup.py check --strict --metadata --restructuredtext
     check-manifest {toxinidir}
     flake8 {posargs:src tests setup.py docs}
-    #isort --verbose --check-only --diff --filter-files .
-
-[testenv:radon]
-deps = radon
-skip_install = true
-commands = 
-    radon cc -s --total-average --no-assert -nb src/
-    radon mi -m -s src/
 
 [testenv:docs]
 usedevelop = true
@@ -80,8 +57,6 @@ deps =
     -r{toxinidir}/docs/requirements.txt
 commands =
     sphinx-build {posargs:-E} -b html docs dist/docs
-    # sphinx-build -b linkcheck docs dist/docs
-
 
 [testenv:codecov]
 deps =
@@ -90,6 +65,13 @@ skip_install = true
 commands =
     codecov []
 
+[testenv:radon]
+deps = radon
+skip_install = true
+commands = 
+    radon cc -s --total-average --no-assert -nb src/
+    radon mi -m -s src/
+
 [testenv:report]
 deps = coverage
 skip_install = true
@@ -97,51 +79,12 @@ commands =
     coverage report
     coverage html
 
-[testenv:clean]
-commands = coverage erase
-skip_install = true
-deps = coverage
-
-[testenv:py37-cover]
-basepython = {env:TOXPYTHON:python3.7}
-setenv =
-    {[testenv]setenv}
-usedevelop = true
-commands =
-    pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv {posargs}    
-deps =
-    {[testenv]deps}
-    pytest-cov
-
-[testenv:py38-cover]
-basepython = {env:TOXPYTHON:python3.8}
-setenv =
-    {[testenv]setenv}
-usedevelop = true
-commands =
-    pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv {posargs}
-deps =
-    {[testenv]deps}
-    pytest-cov
-
 [testenv:py39-cover]
-basepython = {env:TOXPYTHON:python3.9}
 setenv =
     {[testenv]setenv}
 usedevelop = true
 commands =
     pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv {posargs}    
-deps =
-    {[testenv]deps}
-    pytest-cov
-
-[testenv:py310-cover]
-basepython = {env:TOXPYTHON:python3.10}
-setenv =
-    {[testenv]setenv}
-usedevelop = true
-commands =
-    pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv {posargs}
 deps =
     {[testenv]deps}
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ ignore_basepython_conflict = true
 python =
     3.7: py37
     3.8: py38
-    3.9: py39, check, docs, codecov
+    3.9: py39, check, docs
 
 [flake8]
 ignore = E121,E123,E501,W293,W504,W605

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ setenv =
     {[testenv]setenv}
 usedevelop = true
 commands =
-    pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv {posargs}    
+    pytest --cov --cov-report=html:coverage_html --cov-append --cov-config=.coveragerc -vv {posargs}
 deps =
     {[testenv]deps}
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -26,10 +26,10 @@ ignore = E121,E123,E501,W293,W504,W605
 
 [testenv]
 setenv =
-    PYTHONPATH = {toxinidir}/tests
+    PYTHONPATH = {toxinidir}
     PYTHONUNBUFFERED=yes
 deps =
-    -r{toxinidir}/requirements_dev.txt
+    -r{toxinidir}/requirements-dev.txt
 commands =
     pytest --basetemp={envtmpdir} -vv {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ envlist =
     radon,
     report
 ignore_basepython_conflict = true
-requires = tox-conda
 
 [gh-actions]
 python =
@@ -41,20 +40,7 @@ setenv =
     PYTHONUNBUFFERED=yes
 passenv =
     *
-deps =
-    pytest
-    pytest-cov
-    coverage
-conda_deps =
-    mdanalysis
-    freud
-    numpy
-    tidynamics
-conda_channels =
-    conda-forge
-    defaults
-conda_env =
-    requirements-dev.yml
+deps = -rrequirements.txt
 commands =
     pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv {posargs}    
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ envlist =
     py38,
     py39,
     py39-cover,
-    p310,
 ignore_basepython_conflict = true
 
 [gh-actions]
@@ -19,7 +18,6 @@ python =
     3.7: py37
     3.8: py38, check, docs, codecov
     3.9: py39
-    3.10: py310
 
 [flake8]
 ignore = E121,E123,E501,W293,W504,W605

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ setenv =
     {[testenv]setenv}
 usedevelop = true
 commands =
-    pytest --cov --cov-report=html:{toxinidir}/coverage_html --cov-append --cov-config=.coveragerc -vv {posargs}
+    pytest --cov --cov-report=xml:{toxinidir}/coverage.xml --cov-append --cov-config=.coveragerc -vv {posargs}
 deps =
     {[testenv]deps}
     pytest-cov


### PR DESCRIPTION
Fixes #87 

Changes made in this Pull Request:
 - Added a workflow for testing, coverage checking, and building docs with github actions
 - Updated `tox.ini` for use with github actions
 - Using `tox-gh-actions` to run the tests
 - Run tests on Python 3.7-3.9 on both Ubuntu and MacOS (Windows currently fails because it cannot build a wheel for freud-analysis)
 - For Python 3.9 Ubuntu,  LiPyphilic is built, docs are built, flake is run, coverage is checked and uploaded to codecov
 - Required to pass: tests with Python 3.9 (on both Ubuntu and MacOS), coverage of 100%

PR Checklist
------------
 - [ ] Tests added and passing?
 - [ ] Docs added and building?
 - [x] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [x] Issue raised and referenced?
