### PR TITLE
Norm keyowrd imshow

### DIFF
--- a/src/lipyphilic/lib/plotting.py
+++ b/src/lipyphilic/lib/plotting.py
@@ -204,8 +204,8 @@ class ProjectionPlot:
         cmap=None,
         vmin=None, vmax=None,
         cbar=True,
-        cbar_kws={},
-        imshow_kws={},
+        cbar_kws=None,
+        imshow_kws=None,
     ):
         """Plot the 2D projection of a membrane property.
         
@@ -258,6 +258,9 @@ class ProjectionPlot:
         
         # imshow transposes the data
         values = self.statistic.T
+
+        cbar_kws = dict() if cbar_kws is None else cbar_kws
+        imshow_kws = dict() if imshow_kws is None else imshow_kws
 
         # we cannot pass vmin/vmax to imshow if norm is also passed
         if "norm" in imshow_kws:

--- a/src/lipyphilic/lib/plotting.py
+++ b/src/lipyphilic/lib/plotting.py
@@ -258,7 +258,12 @@ class ProjectionPlot:
         
         # imshow transposes the data
         values = self.statistic.T
-        
+
+        # we cannot pass vmin/vmax to imshow if norm is also passed
+        if "norm" in imshow_kws:
+            vmin = min(imshow_kws['norm'].boundaries)
+            vmax = max(imshow_kws['norm'].boundaries)
+
         # we need vmin and vmax to be set to sensible values
         # to ensure the colorbar labels looks reasonable
         # And to clip the values
@@ -268,7 +273,11 @@ class ProjectionPlot:
             vmax = np.ceil(np.nanmax(values))
         
         values = values.clip(vmin, vmax)
-        
+
+        if "norm" not in imshow_kws:
+            imshow_kws['vmin'] = vmin
+            imshow_kws['vmax'] = vmax
+
         # Detmine which cmap to use
         if cmap is None:
             cmap = sns.cubehelix_palette(start=.5, rot=-.75, as_cmap=True, reverse=True)
@@ -278,8 +287,6 @@ class ProjectionPlot:
             values,
             origin='lower',  # this is necessary to make sure the y-axis is not inverted
             cmap=cmap,
-            vmin=vmin,
-            vmax=vmax,
             **imshow_kws
         )
             

--- a/tests/lipyphilic/lib/test_plotting.py
+++ b/tests/lipyphilic/lib/test_plotting.py
@@ -10,8 +10,24 @@ from numpy.testing._private.utils import assert_array_almost_equal  # noqa: E402
 
 from lipyphilic.lib.plotting import JointDensity  # noqa: E402
 from lipyphilic.lib.plotting import ProjectionPlot  # noqa: E402
- 
- 
+
+
+@pytest.fixture(scope="module")
+def norm():
+
+    # Create a colormap
+    cmap = matplotlib.colors.LinearSegmentedColormap.from_list(
+        name="new_cmap",
+        colors=["xkcd:red", "xkcd:sky blue"]
+    )
+
+    # ensure the colourmap is discrete by defining its bounds
+    bounds = [-1, 0, 1]
+    normed_cmap = matplotlib.colors.BoundaryNorm(bounds, cmap.N)
+
+    return normed_cmap
+
+
 class TestProjectionPlot:
     
     kwargs = {
@@ -132,6 +148,16 @@ class TestProjectionPlot:
             'cbar-ticks': np.linspace(0, 1, 6)
         }
         
+        assert_array_almost_equal(projection_data.cbar.get_ticks(), reference['cbar-ticks'])
+
+    def test_norm(self, projection_data, norm):
+    
+        projection_data.plot_projection(imshow_kws={'norm': norm})
+
+        reference = {
+            'cbar-ticks': [-1, 0, 1],
+        }
+
         assert_array_almost_equal(projection_data.cbar.get_ticks(), reference['cbar-ticks'])
         
     def test_cmap(self, projection_data):
@@ -421,21 +447,6 @@ class TestPlotDensity:
         )
         
         return density
-
-    @pytest.fixture()
-    def norm(self):
-
-        # Create a colormap
-        cmap = matplotlib.colors.LinearSegmentedColormap.from_list(
-            name="new_cmap",
-            colors=["xkcd:red", "xkcd:sky blue"]
-        )
-
-        # ensure the colourmap is discrete by defining its bounds
-        bounds = [-1, 0, 1]
-        normed_cmap = matplotlib.colors.BoundaryNorm(bounds, cmap.N)
-
-        return normed_cmap
 
     def test_plot_density(self, density):
         

--- a/tests/lipyphilic/lib/test_plotting.py
+++ b/tests/lipyphilic/lib/test_plotting.py
@@ -376,7 +376,7 @@ class TestInterpolate:
 
 class TestPlotDensity:
     
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     def density(self):
         
         density = JointDensity(
@@ -422,6 +422,21 @@ class TestPlotDensity:
         
         return density
 
+    @pytest.fixture()
+    def norm(self):
+
+        # Create a colormap
+        cmap = matplotlib.colors.LinearSegmentedColormap.from_list(
+            name="new_cmap",
+            colors=["xkcd:red", "xkcd:sky blue"]
+        )
+
+        # ensure the colourmap is discrete by defining its bounds
+        bounds = [-1, 0, 1]
+        normed_cmap = matplotlib.colors.BoundaryNorm(bounds, cmap.N)
+
+        return normed_cmap
+
     def test_plot_density(self, density):
         
         density.plot_density()
@@ -465,6 +480,16 @@ class TestPlotDensity:
             'cbar-ticks': np.linspace(0, 1, 6)
         }
         
+        assert_array_almost_equal(density.cbar.get_ticks(), reference['cbar-ticks'])
+
+    def test_norm(self, density, norm):
+
+        density.plot_density(imshow_kws={'norm': norm})
+
+        reference = {
+            'cbar-ticks': [-1, 0, 1],
+        }
+
         assert_array_almost_equal(density.cbar.get_ticks(), reference['cbar-ticks'])
             
     def test_labels(self, density):


### PR DESCRIPTION
Fixes #84 

Changes made in this Pull Request:
 - If `norm` is present in the `imshow_kws` argument of either `ProjectionPlot.plot_projection` or `JointDensity.plot_density`, then the `vmin` and `vmax` arguments are not passed to `plt.imshow`. This is because an error is raised in matplotlib 3.5 if both `norm` and `vmin/vmax` are passed to `plt.imshow`


PR Checklist
------------
 - [x] Tests added and passing?
 - [ ] Docs added and building?
 - [x] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [x] Issue raised and referenced?
