### PR TITLE
Use attrs and type hints for the MSD analysis class

### DIFF
--- a/src/lipyphilic/lib/lateral_diffusion.py
+++ b/src/lipyphilic/lib/lateral_diffusion.py
@@ -165,7 +165,7 @@ curve from lagtime :math:`\Delta t = 400` to lagtime :math:`\Delta t = 600`.
     :members:
 
 """
-from typing import Optional
+from typing import Optional, Tuple
 
 from attrs import define
 import numpy as np
@@ -259,7 +259,7 @@ class MSD(AnalysisBase):
         start_fit: Optional[float] = None,
         stop_fit: Optional[float] = None,
         lipid_sel: Optional[str] = None,
-    ):
+    ) -> Tuple[float, float]:
         """Calculate the lateral diffusion coefficient via the Einstein relation.
         
         A diffusion is calculated for each lipid through a linear fit to its MSD curve.

--- a/src/lipyphilic/lib/lateral_diffusion.py
+++ b/src/lipyphilic/lib/lateral_diffusion.py
@@ -216,8 +216,7 @@ class MSD(AnalysisBase):
         self.lagtimes = None
         
     def _prepare(self):
-        
-        # Output arrays
+
         self.lipid_com_pos = np.full(
             (self.membrane.n_residues, self.n_frames, 2),
             fill_value=np.NaN,
@@ -228,8 +227,6 @@ class MSD(AnalysisBase):
             (self.membrane.n_residues, self.n_frames),
             fill_value=np.NaN
         )
-        
-        return None
 
     def _single_frame(self):
         
@@ -238,8 +235,6 @@ class MSD(AnalysisBase):
         # Remove COM motion if necessary
         if self.com_removal.n_atoms > 0:
             self.lipid_com_pos[:, self._frame_index] -= self.com_removal.center_of_mass()[:2]
-        
-        return None
     
     def _conclude(self):
         
@@ -258,8 +253,6 @@ class MSD(AnalysisBase):
 
         # Convert A^2 to nm^2
         self.msd /= 100
-        
-        return None
     
     def diffusion_coefficient(self, start_fit=None, stop_fit=None, lipid_sel=None):
         """Calculate the lateral diffusion coefficient via the Einstein relation.

--- a/src/lipyphilic/lib/lateral_diffusion.py
+++ b/src/lipyphilic/lib/lateral_diffusion.py
@@ -254,7 +254,12 @@ class MSD(AnalysisBase):
         # Convert A^2 to nm^2
         self.msd /= 100
     
-    def diffusion_coefficient(self, start_fit=None, stop_fit=None, lipid_sel=None):
+    def diffusion_coefficient(
+        self,
+        start_fit: Optional[float] = None,
+        stop_fit: Optional[float] = None,
+        lipid_sel: Optional[str] = None,
+    ):
         """Calculate the lateral diffusion coefficient via the Einstein relation.
         
         A diffusion is calculated for each lipid through a linear fit to its MSD curve.
@@ -282,7 +287,6 @@ class MSD(AnalysisBase):
         sem : float
             The standard error of the diffusion coefficients.
         """
-        
         if start_fit is None:
             start_fit_index = self.lagtimes.size * 20 // 100
         else:


### PR DESCRIPTION
Changes made in this Pull Request:
 - Use `attrs.define` along with type hints for the `MSD` analysis class.
 - Use type hints for the `MSD.diffusion_coefficient` method
- Unnecessary `return None` statements removed 

PR Checklist
------------
 - [ ] Tests added and passing?
 - [ ] Docs added and building?
