### PR TITLE
Assign 2D histogram diff to memb_thickness_grid

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ Authors (chronological)
 
 * Paul Smith
 * Raquel Lopez-Rios
+* David Goh

--- a/src/lipyphilic/analysis/memb_thickness.py
+++ b/src/lipyphilic/analysis/memb_thickness.py
@@ -281,7 +281,7 @@ class MembThickness(AnalysisBase):
         self.memb_thickness[self._frame_index] = thickness
 
         if self._return_surface:
-            self.memb_thickness_grid[self._frame_index] = thickness
+            self.memb_thickness_grid[self._frame_index] = upper_surface - lower_surface
 
     def _interpolate(self, surface):
         """Interpolate the leaflet intrinsic surface.


### PR DESCRIPTION
Fixes https://github.com/p-j-smith/lipyphilic/issues/100

The mean over the thickness matrix was assigned to self.memb_thickness_grid, which is not the expected behaviour

Changes made in this Pull Request:
 - self.memb_thickness_grid = difference in upper surface and lower surface matrices


PR Checklist
------------
 - [ ] Tests added and passing?
 - [ ] Docs added and building?
 - [ ] CHANGELOG updated?
 - [x] AUTHORS updated if necessary?
 - [x] Issue raised and referenced?
