### PR TITLE
Use the MDA `Results` class for storing analysis results

### DIFF
--- a/src/lipyphilic/analysis/area_per_lipid.py
+++ b/src/lipyphilic/analysis/area_per_lipid.py
@@ -199,7 +199,11 @@ class AreaPerLipid(AnalysisBase):
             lipid: sum(self.membrane.resnames == lipid) // num_lipids[lipid] for lipid in self._lipid_species
         }
 
-        self.areas = None
+        self.results.areas = None
+
+    @property
+    def areas(self):
+        return self.results.areas
 
     def _prepare(self):
         if (self.leaflets.ndim == 2) and (self.leaflets.shape[1] != self.n_frames):
@@ -207,7 +211,7 @@ class AreaPerLipid(AnalysisBase):
             raise ValueError(_msg)
 
         # Output array
-        self.areas = np.full(
+        self.results.areas = np.full(
             (self.membrane.n_residues, self.n_frames),
             fill_value=np.NaN,
             dtype=float,
@@ -348,7 +352,7 @@ class AreaPerLipid(AnalysisBase):
                 assume_unique=True,
             )
 
-            self.areas[species_resindices, self._frame_index] = species_apl
+            self.results.areas[species_resindices, self._frame_index] = species_apl
 
         return
 
@@ -460,7 +464,10 @@ class AreaPerLipid(AnalysisBase):
         if filter_by is not None:
             filter_by = np.array(filter_by)
 
-            if not ((self.areas.shape == filter_by.shape) or (self.areas.shape[:1] == filter_by.shape)):
+            if not (
+                (self.results.areas.shape == filter_by.shape)
+                or (self.results.areas.shape[:1] == filter_by.shape)
+            ):
                 _msg = "The shape of `filter_by` must either be (n_lipids, n_frames) or (n_lipids)"
                 raise ValueError(_msg)
 
@@ -476,14 +483,14 @@ class AreaPerLipid(AnalysisBase):
         frames = self.frames[keep_frames]
 
         # Data for projecting and frame from which to extract lipid positions
-        areas = self.areas[keep_lipids][:, keep_frames]
+        areas = self.results.areas[keep_lipids][:, keep_frames]
         mid_frame = frames[frames.size // 2]
 
         # Check whether we need to filter the lipids
         if filter_by is None:
             filter_by = np.full(areas.shape[0], fill_value=True)
 
-        elif filter_by.shape == self.areas.shape[:1]:
+        elif filter_by.shape == self.results.areas.shape[:1]:
             filter_by = filter_by[keep_lipids]
 
         else:

--- a/src/lipyphilic/analysis/flip_flop.py
+++ b/src/lipyphilic/analysis/flip_flop.py
@@ -215,6 +215,14 @@ class FlipFlop(AnalysisBase):
         self.results.flip_flops = None
         self.results.flip_flop_success = None
 
+    @property
+    def flip_flops(self):
+        return self.results.flip_flops
+
+    @property
+    def flip_flop_success(self):
+        return self.results.flip_flop_success
+
     def _setup_frames(self, trajectory, start=None, stop=None, step=None):
         """
         Pass a Reader object and define the desired iteration pattern

--- a/src/lipyphilic/analysis/flip_flop.py
+++ b/src/lipyphilic/analysis/flip_flop.py
@@ -212,8 +212,8 @@ class FlipFlop(AnalysisBase):
 
         self.frame_cutoff = frame_cutoff
 
-        self.flip_flops = None
-        self.flip_flop_success = None
+        self.results.flip_flops = None
+        self.results.flip_flop_success = None
 
     def _setup_frames(self, trajectory, start=None, stop=None, step=None):
         """
@@ -248,8 +248,8 @@ class FlipFlop(AnalysisBase):
 
     def _prepare(self):
         # Output array
-        self.flip_flops = [[], [], [], []]
-        self.flip_flop_success = []
+        self.results.flip_flops = [[], [], [], []]
+        self.results.flip_flop_success = []
 
     def _single_frame(self):
         # Skip if the molecule never changes leaflet
@@ -263,15 +263,15 @@ class FlipFlop(AnalysisBase):
 
         n_events = len(start_frames)
         resindex = self.membrane[self._residue_index].resindex
-        self.flip_flops[0].extend([resindex for _ in range(n_events)])
-        self.flip_flops[1].extend(start_frames)
-        self.flip_flops[2].extend(end_frames)
-        self.flip_flops[3].extend(end_leaflets)
-        self.flip_flop_success.extend(success)
+        self.results.flip_flops[0].extend([resindex for _ in range(n_events)])
+        self.results.flip_flops[1].extend(start_frames)
+        self.results.flip_flops[2].extend(end_frames)
+        self.results.flip_flops[3].extend(end_leaflets)
+        self.results.flip_flop_success.extend(success)
 
     def _conclude(self):
-        self.flip_flops = np.asarray(self.flip_flops).T
-        self.flip_flop_success = np.asarray(self.flip_flop_success)
+        self.results.flip_flops = np.asarray(self.results.flip_flops).T
+        self.results.flip_flop_success = np.asarray(self.results.flip_flop_success)
 
     def run(self, start=None, stop=None, step=None):
         """Perform the calculation

--- a/src/lipyphilic/analysis/lateral_diffusion.py
+++ b/src/lipyphilic/analysis/lateral_diffusion.py
@@ -216,6 +216,14 @@ class MSD(AnalysisBase):
         self.results.msd = None
         self.results.lagtimes = None
 
+    @property
+    def msd(self):
+        return self.results.msd
+
+    @property
+    def lagtimes(self):
+        return self.results.lagtimes
+
     def _prepare(self):
         self.lipid_com_pos = np.full(
             (self.membrane.n_residues, self.n_frames, 2),

--- a/src/lipyphilic/analysis/memb_thickness.py
+++ b/src/lipyphilic/analysis/memb_thickness.py
@@ -214,6 +214,10 @@ class MembThickness(AnalysisBase):
         self._return_surface = return_surface
         self.results.memb_thickness = None
 
+    @property
+    def memb_thickness(self):
+        return self.results.memb_thickness
+
     def _prepare(self):
         if (self.leaflets.ndim == 2) and (self.leaflets.shape[1] != self.n_frames):
             _msg = "The frames to analyse must be identical to those used in assigning lipids to leaflets."

--- a/src/lipyphilic/analysis/memb_thickness.py
+++ b/src/lipyphilic/analysis/memb_thickness.py
@@ -212,7 +212,7 @@ class MembThickness(AnalysisBase):
         self.n_bins = n_bins
         self._interpolate_surfaces = interpolate
         self._return_surface = return_surface
-        self.memb_thickness = None
+        self.results.memb_thickness = None
 
     def _prepare(self):
         if (self.leaflets.ndim == 2) and (self.leaflets.shape[1] != self.n_frames):
@@ -220,7 +220,7 @@ class MembThickness(AnalysisBase):
             raise ValueError(_msg)
 
         # Output array
-        self.memb_thickness = np.full(self.n_frames, fill_value=np.NaN)
+        self.results.memb_thickness = np.full(self.n_frames, fill_value=np.NaN)
 
         if self._return_surface:
             self.memb_thickness_grid = np.full(
@@ -278,7 +278,7 @@ class MembThickness(AnalysisBase):
             else (upper_surface - lower_surface)[0, 0]
         )
 
-        self.memb_thickness[self._frame_index] = thickness
+        self.results.memb_thickness[self._frame_index] = thickness
 
         if self._return_surface:
             self.memb_thickness_grid[self._frame_index] = upper_surface - lower_surface

--- a/src/lipyphilic/analysis/neighbours.py
+++ b/src/lipyphilic/analysis/neighbours.py
@@ -288,10 +288,14 @@ class Neighbours(AnalysisBase):
 
         self.cutoff = cutoff
 
-        self.neighbours = None
+        self.results.neighbours = None
+
+    @property
+    def neighbours(self):
+        return self.results.neighbours
 
     def _prepare(self):
-        self.neighbours = np.zeros(self.n_frames, dtype=object)
+        self.results.neighbours = np.zeros(self.n_frames, dtype=object)
 
     def _single_frame(self):
         pairs = capped_distance(
@@ -313,7 +317,7 @@ class Neighbours(AnalysisBase):
 
         # store neighbours for this frame
         data = np.ones_like(ref)
-        self.neighbours[self._frame_index] = scipy.sparse.csr_matrix(
+        self.results.neighbours[self._frame_index] = scipy.sparse.csr_matrix(
             (data, (ref, neigh)),
             dtype=np.int8,
             shape=(self.membrane.n_residues, self.membrane.n_residues),
@@ -354,7 +358,7 @@ class Neighbours(AnalysisBase):
 
         """
 
-        if self.neighbours is None:
+        if self.results.neighbours is None:
             _msg = ".neighbours attribute is None: use .run() before calling .count_neighbours()"
             raise NoDataError(_msg)
 
@@ -392,7 +396,7 @@ class Neighbours(AnalysisBase):
 
         # Get counts at each frame
         n_residues = self.membrane.n_residues
-        for frame_index, neighbours in tqdm(enumerate(self.neighbours), total=self.n_frames):
+        for frame_index, neighbours in tqdm(enumerate(self.results.neighbours), total=self.n_frames):
             ref, neigh = neighbours.nonzero()
             unique, counts = np.unique(
                 [ref, [type_index[t] for t in count_by[neigh, frame_index]]],
@@ -526,7 +530,7 @@ class Neighbours(AnalysisBase):
 
         """
 
-        if self.neighbours is None:
+        if self.results.neighbours is None:
             _msg = ".neighbours attribute is None: use .run() before calling .largest_cluster()"
             raise NoDataError(_msg)
 
@@ -582,7 +586,7 @@ class Neighbours(AnalysisBase):
         largest_cluster = np.zeros(self.n_frames, dtype=int)
         largest_cluster_resindices = np.full(self.n_frames, fill_value=0, dtype=object)
 
-        for frame_index, neighbours in tqdm(enumerate(self.neighbours), total=self.n_frames):
+        for frame_index, neighbours in tqdm(enumerate(self.results.neighbours), total=self.n_frames):
             frame_filter = filter_by[:, frame_index]
             frame_neighbours = neighbours[frame_filter][:, frame_filter]
 

--- a/src/lipyphilic/analysis/registration.py
+++ b/src/lipyphilic/analysis/registration.py
@@ -317,11 +317,15 @@ class Registration(AnalysisBase):
         self.n_bins = n_bins
         self.gaussian_sd = gaussian_sd
 
-        self.registration = None
+        self.results.registration = None
+
+    @property
+    def registration(self):
+        return self.results.registration
 
     def _prepare(self):
         # Output array
-        self.registration = np.full(self.n_frames, fill_value=np.NaN)
+        self.results.registration = np.full(self.n_frames, fill_value=np.NaN)
 
     def _single_frame(self):
         # Atoms must be inside the primary unit cell
@@ -380,4 +384,4 @@ class Registration(AnalysisBase):
             upper_hist.flatten(),
             lower_hist.flatten(),
         )
-        self.registration[self._frame_index] = correlation[0]
+        self.results.registration[self._frame_index] = correlation[0]

--- a/src/lipyphilic/analysis/z_angles.py
+++ b/src/lipyphilic/analysis/z_angles.py
@@ -152,11 +152,15 @@ class ZAngles(AnalysisBase):
             raise ValueError(_msg)
 
         self.rad = rad
-        self.z_angles = None
+        self.results.z_angles = None
+
+    @property
+    def z_angles(self):
+        return self.results.z_angles
 
     def _prepare(self):
         # Output array
-        self.z_angles = np.full(
+        self.results.z_angles = np.full(
             (self.atom_A.n_residues, self.n_frames),
             fill_value=np.NaN,
         )
@@ -176,4 +180,4 @@ class ZAngles(AnalysisBase):
         if self.rad is False:
             angles = np.rad2deg(angles)
 
-        self.z_angles[:, self._frame_index] = angles
+        self.results.z_angles[:, self._frame_index] = angles

--- a/src/lipyphilic/analysis/z_positions.py
+++ b/src/lipyphilic/analysis/z_positions.py
@@ -188,11 +188,15 @@ class ZPositions(AnalysisBase):
         }
 
         self.n_bins = n_bins
-        self.z_positions = None
+        self.results.z_positions = None
+
+    @property
+    def z_positions(self):
+        return self.results.z_positions
 
     def _prepare(self):
         # Output array
-        self.z_positions = np.full(
+        self.results.z_positions = np.full(
             (self._height_atoms.n_residues, self.n_frames),
             fill_value=np.NaN,
         )
@@ -257,4 +261,4 @@ class ZPositions(AnalysisBase):
                 assume_unique=True,
             )
 
-            self.z_positions[species_resindices, self._frame_index] = species_zpos
+            self.results.z_positions[species_resindices, self._frame_index] = species_zpos

--- a/src/lipyphilic/analysis/z_thickness.py
+++ b/src/lipyphilic/analysis/z_thickness.py
@@ -151,11 +151,15 @@ class ZThickness(AnalysisBase):
             species: self.lipids.residues.resnames == species for species in np.unique(self.lipids.resnames)
         }
 
-        self.z_thickness = None
+        self.results.z_thickness = None
+
+    @property
+    def z_thickness(self):
+        return self.results.z_thickness
 
     def _prepare(self):
         # Output array
-        self.z_thickness = np.full(
+        self.results.z_thickness = np.full(
             (self.lipids.n_residues, self.n_frames),
             fill_value=np.NaN,
         )
@@ -171,7 +175,7 @@ class ZThickness(AnalysisBase):
             z_dim = self._ts.dimensions[2]
             thicknesses[thicknesses > z_dim / 2] = z_dim - thicknesses[thicknesses > z_dim / 2]
 
-            self.z_thickness[self.lipid_residue_mask[species], self._frame_index] = thicknesses
+            self.results.z_thickness[self.lipid_residue_mask[species], self._frame_index] = thicknesses
 
     @staticmethod
     def average(sn1_thickness, sn2_thickness):
@@ -219,7 +223,9 @@ class ZThickness(AnalysisBase):
         for species in resnames:
             if species not in sn1_thickness.lipids.resnames:
                 # Use sn2 tail only
-                species_thickness = sn2_thickness.z_thickness[sn2_thickness.lipid_residue_mask[species]]
+                species_thickness = sn2_thickness.results.z_thickness[
+                    sn2_thickness.lipid_residue_mask[species]
+                ]
                 species_resindices = np.in1d(
                     combined_resindices,
                     sn2_resindices[sn2_thickness.lipid_residue_mask[species]],
@@ -228,7 +234,9 @@ class ZThickness(AnalysisBase):
 
             elif species not in sn2_thickness.lipids.resnames:
                 # Use sn1 tail only
-                species_thickness = sn1_thickness.z_thickness[sn1_thickness.lipid_residue_mask[species]]
+                species_thickness = sn1_thickness.results.z_thickness[
+                    sn1_thickness.lipid_residue_mask[species]
+                ]
                 species_resindices = np.in1d(
                     combined_resindices,
                     sn1_resindices[sn1_thickness.lipid_residue_mask[species]],
@@ -237,8 +245,12 @@ class ZThickness(AnalysisBase):
 
             else:
                 # Calculate mean thickness for the lipid based on the number of atoms in both tails
-                sn1_species_thickness = sn1_thickness.z_thickness[sn1_thickness.lipid_residue_mask[species]]
-                sn2_species_thickness = sn2_thickness.z_thickness[sn2_thickness.lipid_residue_mask[species]]
+                sn1_species_thickness = sn1_thickness.results.z_thickness[
+                    sn1_thickness.lipid_residue_mask[species]
+                ]
+                sn2_species_thickness = sn2_thickness.results.z_thickness[
+                    sn2_thickness.lipid_residue_mask[species]
+                ]
                 species_thickness = (sn1_species_thickness + sn2_species_thickness) / 2
 
                 species_resindices = np.in1d(
@@ -266,6 +278,6 @@ class ZThickness(AnalysisBase):
         new_thickness.n_frames = new_thickness.frames.size
         new_thickness.times = sn1_thickness.times
         new_thickness._trajectory = sn1_thickness._trajectory
-        new_thickness.z_thickness = z_thickness
+        new_thickness.results.z_thickness = z_thickness
 
         return new_thickness

--- a/src/lipyphilic/leaflets/assign_leaflets.py
+++ b/src/lipyphilic/leaflets/assign_leaflets.py
@@ -267,6 +267,12 @@ class AssignLeafletsBase(AnalysisBase):
             )
             raise ValueError(_msg)
 
+        self.results.leaflets = None
+
+    @property
+    def leaflets(self):
+        return self.results.leaflets
+
     def _assign_leaflets(self):
         """Assign lipids to the upper (1) or lower (-1) leaflet."""
         # pragma: no cover
@@ -363,11 +369,11 @@ class AssignLeaflets(AssignLeafletsBase):
             raise ValueError(_msg)
 
         self.n_bins = n_bins
-        self.leaflets = None
+        self.results.leaflets = None
 
     def _prepare(self):
         # Output array
-        self.leaflets = np.full(
+        self.results.leaflets = np.full(
             (self.membrane.n_residues, self.n_frames),
             fill_value=0,
             dtype=np.int8,  # smallest sized `np.int` is 1 byte, still 8 times smaller than using `int`
@@ -434,7 +440,7 @@ class AssignLeaflets(AssignLeafletsBase):
                 memb_midpoint_xy.statistic[lipid_x_bins, lipid_y_bins]
             )  # we don't to consider midplane_cutoff here
         ]
-        self.leaflets[
+        self.results.leaflets[
             np.in1d(self.membrane.residues.resindices, upper_leaflet.residues.resindices),
             self._frame_index,
         ] = 1
@@ -445,7 +451,7 @@ class AssignLeaflets(AssignLeafletsBase):
                 memb_midpoint_xy.statistic[lipid_x_bins, lipid_y_bins]
             )  # we don't to consider midplane_cutoff here
         ]
-        self.leaflets[
+        self.results.leaflets[
             np.in1d(self.membrane.residues.resindices, lower_leaflet.residues.resindices),
             self._frame_index,
         ] = -1
@@ -505,7 +511,7 @@ class AssignLeaflets(AssignLeafletsBase):
         midplane_residues = self.potential_midplane.residues[midplane_mask]
 
         # Assign midplane
-        self.leaflets[
+        self.results.leaflets[
             np.in1d(self.membrane.residues.resindices, midplane_residues.resindices),
             self._frame_index,
         ] = 0
@@ -565,7 +571,7 @@ class AssignCurvedLeaflets(AssignLeafletsBase):
 
     def _prepare(self):
         # Output array
-        self.leaflets = np.full(
+        self.results.leaflets = np.full(
             (self.membrane.n_residues, self.n_frames),
             fill_value=0,
             dtype=np.int8,  # smallest sized `np.int` is 1 byte, still 8 times smaller than using `int`
@@ -635,8 +641,8 @@ class AssignCurvedLeaflets(AssignLeafletsBase):
 
         self._upper = upper
         self._lower = lower
-        self.leaflets[upper_mask] = 1
-        self.leaflets[lower_mask] = -1
+        self.results.leaflets[upper_mask] = 1
+        self.results.leaflets[lower_mask] = -1
 
         return
 
@@ -671,8 +677,8 @@ class AssignCurvedLeaflets(AssignLeafletsBase):
         # Those in both or neither = midplane
         in_upper = np.in1d(upper_resindices, lower_resindices, invert=True)
         add_to_upper = np.in1d(self.membrane.residues.resindices, upper_resindices[in_upper])
-        self.leaflets[add_to_upper, self._frame_index] = 1
+        self.results.leaflets[add_to_upper, self._frame_index] = 1
 
         in_lower = np.in1d(lower_resindices, upper_resindices, invert=True)
         add_to_lower = np.in1d(self.membrane.residues.resindices, lower_resindices[in_lower])
-        self.leaflets[add_to_lower, self._frame_index] = -1
+        self.results.leaflets[add_to_lower, self._frame_index] = -1

--- a/tests/lipyphilic/lib/test_area_per_lipid.py
+++ b/tests/lipyphilic/lib/test_area_per_lipid.py
@@ -42,8 +42,8 @@ class TestAreaPerLipid:
             "area": 200,  # all lipids have the same area per lipid as they are on a hexagonal lattice
         }
 
-        assert areas.areas.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(areas.areas, 200.0, decimal=8)
+        assert areas.results.areas.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(areas.results.areas, 200.0, decimal=8)
 
 
 class TestAreaPerLipidOverlapping:
@@ -67,7 +67,7 @@ class TestAreaPerLipidOverlapping:
 
     def test_area_per_lipid(self, areas):
         # only the areas of 6 residues should be affected by these two overlapping atoms
-        assert np.isclose(areas.areas, 200).sum() == 94
+        assert np.isclose(areas.results.areas, 200).sum() == 94
 
 
 class TestAreaPerLipidMidplaneMol:
@@ -99,10 +99,10 @@ class TestAreaPerLipidMidplaneMol:
             "min_area": 200,  # all lipids have at least this area
         }
 
-        assert areas.areas.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(np.nanmin(areas.areas), 200.0, decimal=8)
-        assert np.isnan(areas.areas[78])
-        assert sum(np.isnan(areas.areas)) == 1
+        assert areas.results.areas.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(np.nanmin(areas.results.areas), 200.0, decimal=8)
+        assert np.isnan(areas.results.areas[78])
+        assert sum(np.isnan(areas.results.areas)) == 1
 
 
 class TestAreaPerLipidExceptions:
@@ -181,17 +181,17 @@ class TestProjectArea:
         area_projection = areas.project_area()
 
         assert isinstance(area_projection, ProjectionPlot)
-        assert_array_almost_equal(area_projection.values, areas.areas.mean())
+        assert_array_almost_equal(area_projection.values, areas.results.areas.mean())
 
     def test_filter_by(self, areas):
         area_projection = areas.project_area(filter_by=np.full(100, fill_value=True))
 
-        assert_array_almost_equal(area_projection.values, areas.areas.mean())
+        assert_array_almost_equal(area_projection.values, areas.results.areas.mean())
 
     def test_filter_by_2D(self, areas):
         area_projection = areas.project_area(filter_by=np.full((100, 1), fill_value=True))
 
-        assert_array_almost_equal(area_projection.values, areas.areas.mean())
+        assert_array_almost_equal(area_projection.values, areas.results.areas.mean())
 
     def test_filter_by_exception(self, areas):
         match = "The shape of `filter_by` must either be \\(n_lipids, n_frames\\) or \\(n_lipids\\)"

--- a/tests/lipyphilic/lib/test_assign_leaflets.py
+++ b/tests/lipyphilic/lib/test_assign_leaflets.py
@@ -39,8 +39,8 @@ class TestAssignLeaflets:
             ],  # all lipids should be assigned to the lower (-1) or upper (1) leaflet
         }
 
-        assert leaflets.leaflets.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_equal(np.unique(leaflets.leaflets), reference["leaflets_present"])
+        assert leaflets.results.leaflets.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_equal(np.unique(leaflets.results.leaflets), reference["leaflets_present"])
 
         # first 50 residues are in the upper leaflet (1)
         # final 50 residues are in the lower leaflet (-1)
@@ -48,7 +48,7 @@ class TestAssignLeaflets:
             "assigned": np.array([[1]] * 50 + [[-1]] * 50),
         }
 
-        assert_array_equal(leaflets.leaflets, reference["assigned"])
+        assert_array_equal(leaflets.results.leaflets, reference["assigned"])
 
     def test_filter_leaflets(self, leaflets):
         reference = {
@@ -144,12 +144,12 @@ class TestAssignLeafletsUndulating:
             "midplane_resnames": ["CHOL"] * 6,  # list or residues incorrectly identified as midplane
         }
 
-        assert_array_equal(np.unique(leaflets.leaflets), reference["leaflets_present"])
+        assert_array_equal(np.unique(leaflets.results.leaflets), reference["leaflets_present"])
         assert_array_equal(
-            universe.residues[leaflets.leaflets[:, 0] == 0].resnames,
+            universe.residues[leaflets.results.leaflets[:, 0] == 0].resnames,
             reference["midplane_resnames"],
         )
-        assert "LIPID" not in universe.residues[leaflets.leaflets[:, 0] == 0].resnames
+        assert "LIPID" not in universe.residues[leaflets.results.leaflets[:, 0] == 0].resnames
 
     def test_nbins4(self, universe):
         leaflets = lpp.AssignLeaflets(universe, n_bins=4, **self.kwargs)
@@ -160,9 +160,9 @@ class TestAssignLeafletsUndulating:
             "midplane_resnames": [],  # list or residues incorrectly identified as midplane
         }
 
-        assert_array_equal(np.unique(leaflets.leaflets), reference["leaflets_present"])
+        assert_array_equal(np.unique(leaflets.results.leaflets), reference["leaflets_present"])
         assert_array_equal(
-            universe.residues[leaflets.leaflets[:, 0] == 0].resnames,
+            universe.residues[leaflets.results.leaflets[:, 0] == 0].resnames,
             reference["midplane_resnames"],
         )
 
@@ -196,13 +196,13 @@ class TestAssignLeafletsUndulatingMidplaneMol:
             "midplane_resids": [78],  # resid of midplane molecules
         }
 
-        assert_array_equal(np.unique(leaflets.leaflets), reference["leaflets_present"])
+        assert_array_equal(np.unique(leaflets.results.leaflets), reference["leaflets_present"])
         assert_array_equal(
-            universe.residues[leaflets.leaflets[:, 0] == 0].resnames,
+            universe.residues[leaflets.results.leaflets[:, 0] == 0].resnames,
             reference["midplane_resnames"],
         )
         assert_array_equal(
-            universe.residues[leaflets.leaflets[:, 0] == 0].resids,
+            universe.residues[leaflets.results.leaflets[:, 0] == 0].resids,
             reference["midplane_resids"],
         )
 
@@ -236,13 +236,13 @@ class TestAssignLeafletsUndulatingMidplaneAtom:
             "midplane_resids": [],
         }
 
-        assert_array_equal(np.unique(leaflets.leaflets), reference["leaflets_present"])
+        assert_array_equal(np.unique(leaflets.results.leaflets), reference["leaflets_present"])
         assert_array_equal(
-            universe.residues[leaflets.leaflets[:, 0] == 0].resnames,
+            universe.residues[leaflets.results.leaflets[:, 0] == 0].resnames,
             reference["midplane_resnames"],
         )
         assert_array_equal(
-            universe.residues[leaflets.leaflets[:, 0] == 0].resids,
+            universe.residues[leaflets.results.leaflets[:, 0] == 0].resids,
             reference["midplane_resids"],
         )
 
@@ -267,9 +267,9 @@ class TestAssignCurvedLeafletsUndulating:
             "midplane_resnames": [],
         }
 
-        assert_array_equal(np.unique(leaflets.leaflets), reference["leaflets_present"])
+        assert_array_equal(np.unique(leaflets.results.leaflets), reference["leaflets_present"])
         assert_array_equal(
-            universe.residues[leaflets.leaflets[:, 0] == 0].resnames,
+            universe.residues[leaflets.results.leaflets[:, 0] == 0].resnames,
             reference["midplane_resnames"],
         )
 
@@ -297,12 +297,12 @@ class TestAssignCurvedLeafletsUndulatingMidplaneMol:
             "midplane_resids": [78],  # resid of midplane molecules
         }
 
-        assert_array_equal(np.unique(leaflets.leaflets), reference["leaflets_present"])
+        assert_array_equal(np.unique(leaflets.results.leaflets), reference["leaflets_present"])
         assert_array_equal(
-            universe.residues[leaflets.leaflets[:, 0] == 0].resnames,
+            universe.residues[leaflets.results.leaflets[:, 0] == 0].resnames,
             reference["midplane_resnames"],
         )
         assert_array_equal(
-            universe.residues[leaflets.leaflets[:, 0] == 0].resids,
+            universe.residues[leaflets.results.leaflets[:, 0] == 0].resids,
             reference["midplane_resids"],
         )

--- a/tests/lipyphilic/lib/test_flip_flop.py
+++ b/tests/lipyphilic/lib/test_flip_flop.py
@@ -51,8 +51,8 @@ class TestFlipFlop:
             "success": ["Success", "Fail", "Success"],
         }
 
-        assert_array_equal(flip_flop.flip_flops, reference["events"])
-        assert_array_equal(flip_flop.flip_flop_success, reference["success"])
+        assert_array_equal(flip_flop.results.flip_flops, reference["events"])
+        assert_array_equal(flip_flop.results.flip_flop_success, reference["success"])
 
     def test_flip_flop_framecut2(self, universe, leaflets, lipid_sel="name ROH"):
         # only two flip-flop events found now, both successful
@@ -72,8 +72,8 @@ class TestFlipFlop:
             "success": ["Success", "Success"],
         }
 
-        assert_array_equal(flip_flop.flip_flops, reference["events"])
-        assert_array_equal(flip_flop.flip_flop_success, reference["success"])
+        assert_array_equal(flip_flop.results.flip_flops, reference["events"])
+        assert_array_equal(flip_flop.results.flip_flop_success, reference["success"])
 
     def test_flip_flop_framecut8(self, universe, leaflets, lipid_sel="name ROH"):
         # No finished flip-flops - single ongoing flip-flop
@@ -91,8 +91,8 @@ class TestFlipFlop:
             "success": np.array(["Ongoing"]),
         }
 
-        assert_array_equal(flip_flop.flip_flops, reference["events"])
-        assert_array_equal(flip_flop.flip_flop_success, reference["success"])
+        assert_array_equal(flip_flop.results.flip_flops, reference["events"])
+        assert_array_equal(flip_flop.results.flip_flop_success, reference["success"])
 
     def test_flip_flop_framecut14(self, universe, leaflets, lipid_sel="name ROH"):
         # No events start
@@ -110,8 +110,8 @@ class TestFlipFlop:
             "success": np.array([]),
         }
 
-        assert_array_equal(flip_flop.flip_flops, reference["events"])
-        assert_array_equal(flip_flop.flip_flop_success, reference["success"])
+        assert_array_equal(flip_flop.results.flip_flops, reference["events"])
+        assert_array_equal(flip_flop.results.flip_flop_success, reference["success"])
 
     def test_flip_flop_same_leaflet(self, universe, leaflets, lipid_sel="name ROH"):
         flip_flop = FlipFlop(
@@ -126,8 +126,8 @@ class TestFlipFlop:
             "success": np.array([]),
         }
 
-        assert_array_equal(flip_flop.flip_flops, reference["events"])
-        assert_array_equal(flip_flop.flip_flop_success, reference["success"])
+        assert_array_equal(flip_flop.results.flip_flops, reference["events"])
+        assert_array_equal(flip_flop.results.flip_flop_success, reference["success"])
 
     def test_flip_flop_upper_mid_only(self, universe, leaflets, lipid_sel="name ROH"):
         leaflets = np.ones_like(leaflets, dtype=np.int8)
@@ -145,8 +145,8 @@ class TestFlipFlop:
             "success": np.array(["Fail"]),
         }
 
-        assert_array_equal(flip_flop.flip_flops, reference["events"])
-        assert_array_equal(flip_flop.flip_flop_success, reference["success"])
+        assert_array_equal(flip_flop.results.flip_flops, reference["events"])
+        assert_array_equal(flip_flop.results.flip_flop_success, reference["success"])
 
     def test_flip_flop_lower_mid_only(self, universe, leaflets, lipid_sel="name ROH"):
         leaflets = np.ones_like(leaflets, dtype=np.int8) * -1
@@ -164,8 +164,8 @@ class TestFlipFlop:
             "success": np.array(["Fail"]),
         }
 
-        assert_array_equal(flip_flop.flip_flops, reference["events"])
-        assert_array_equal(flip_flop.flip_flop_success, reference["success"])
+        assert_array_equal(flip_flop.results.flip_flops, reference["events"])
+        assert_array_equal(flip_flop.results.flip_flop_success, reference["success"])
 
 
 class TestAreaPerLipidExceptions:

--- a/tests/lipyphilic/lib/test_lateral_diffusion.py
+++ b/tests/lipyphilic/lib/test_lateral_diffusion.py
@@ -28,9 +28,9 @@ class TestMSD:
             "lagtimes": [0.0, 5.0],
         }
 
-        assert msd.msd.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(msd.msd, reference["msd"])
-        assert_array_almost_equal(msd.lagtimes, reference["lagtimes"])
+        assert msd.results.msd.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(msd.results.msd, reference["msd"])
+        assert_array_almost_equal(msd.results.lagtimes, reference["lagtimes"])
 
     def test_msd_com_removal(self, universe):
         msd = MSD(universe, **self.kwargs, com_removal_sel="all")
@@ -43,15 +43,15 @@ class TestMSD:
             "lagtimes": [0.0, 5.0],
         }
 
-        assert msd.msd.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(msd.msd, reference["msd"])
-        assert_array_almost_equal(msd.lagtimes, reference["lagtimes"])
+        assert msd.results.msd.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(msd.results.msd, reference["msd"])
+        assert_array_almost_equal(msd.results.lagtimes, reference["lagtimes"])
 
     def test_diffusion_coefficient(self, universe):
         msd = MSD(universe, **self.kwargs, com_removal_sel="all")
 
-        msd.msd = np.asarray([np.arange(100)])
-        msd.lagtimes = np.arange(100)
+        msd.results.msd = np.asarray([np.arange(100)])
+        msd.results.lagtimes = np.arange(100)
 
         reference = {
             "d": 0.25 * 1e-5,
@@ -65,8 +65,8 @@ class TestMSD:
     def test_diffusion_coefficient_start_stop(self, universe):
         msd = MSD(universe, **self.kwargs)
 
-        msd.msd = np.asarray([np.arange(100)])
-        msd.lagtimes = np.arange(100)
+        msd.results.msd = np.asarray([np.arange(100)])
+        msd.results.lagtimes = np.arange(100)
 
         reference = {
             "d": 0.25 * 1e-5,
@@ -80,8 +80,8 @@ class TestMSD:
     def test_diffusion_coefficient_lipid_sel(self, universe):
         msd = MSD(universe, **self.kwargs)
 
-        msd.msd = np.asarray([np.arange(100)])
-        msd.lagtimes = np.arange(100)
+        msd.results.msd = np.asarray([np.arange(100)])
+        msd.results.lagtimes = np.arange(100)
 
         reference = {
             "d": 0.25 * 1e-5,

--- a/tests/lipyphilic/lib/test_memb_thickness.py
+++ b/tests/lipyphilic/lib/test_memb_thickness.py
@@ -30,8 +30,8 @@ class TestMembThickness:
             "thickness": [20],
         }
 
-        assert memb_thickness.memb_thickness.shape == (reference["n_frames"],)
-        assert_array_equal(memb_thickness.memb_thickness, reference["thickness"])
+        assert memb_thickness.results.memb_thickness.shape == (reference["n_frames"],)
+        assert_array_equal(memb_thickness.results.memb_thickness, reference["thickness"])
 
 
 class TestMembThicknessUndulating:
@@ -66,7 +66,7 @@ class TestMembThicknessUndulating:
         memb_thickness = MembThickness(universe, n_bins=4, **self.kwargs)
         memb_thickness.run()
 
-        assert_array_equal(memb_thickness.memb_thickness, self.reference["thickness"])
+        assert_array_equal(memb_thickness.results.memb_thickness, self.reference["thickness"])
 
     def test_nbins200_no_interpolation(self, universe):
         memb_thickness = MembThickness(universe, n_bins=200, **self.kwargs)
@@ -76,7 +76,7 @@ class TestMembThicknessUndulating:
             "thickness": [np.NaN],
         }
 
-        assert_array_equal(memb_thickness.memb_thickness, reference["thickness"])
+        assert_array_equal(memb_thickness.results.memb_thickness, reference["thickness"])
 
     def test_nbins200_with_interpolation(self, universe):
         memb_thickness = MembThickness(universe, n_bins=200, interpolate=True, **self.kwargs)
@@ -86,7 +86,7 @@ class TestMembThicknessUndulating:
             "thickness": [20],
         }
 
-        assert_array_equal(memb_thickness.memb_thickness, reference["thickness"])
+        assert_array_equal(memb_thickness.results.memb_thickness, reference["thickness"])
 
     def test_return_surface(self, universe):
         # Shift the first 20 atoms by 10 Å in z so that the thickness is non-uniform

--- a/tests/lipyphilic/lib/test_neighbours.py
+++ b/tests/lipyphilic/lib/test_neighbours.py
@@ -30,9 +30,9 @@ class TestNeighbours:
             "n_neighbours": 6,
         }
 
-        assert neighbours.neighbours.shape[0] == (reference["n_frames"])
-        assert neighbours.neighbours[0].shape == (reference["n_residues"], reference["n_residues"])
-        assert (np.sum(neighbours.neighbours[0].toarray(), axis=0) == reference["n_neighbours"]).all()
+        assert neighbours.results.neighbours.shape[0] == (reference["n_frames"])
+        assert neighbours.results.neighbours[0].shape == (reference["n_residues"], reference["n_residues"])
+        assert (np.sum(neighbours.results.neighbours[0].toarray(), axis=0) == reference["n_neighbours"]).all()
 
     def test_neighbours_cutoff10(self, universe):
         neighbours = Neighbours(universe, **self.kwargs, cutoff=10)
@@ -46,9 +46,9 @@ class TestNeighbours:
             "n_neighbours": 2,
         }
 
-        assert neighbours.neighbours.shape[0] == (reference["n_frames"])
-        assert neighbours.neighbours[0].shape == (reference["n_residues"], reference["n_residues"])
-        assert (np.sum(neighbours.neighbours[0].toarray(), axis=0) == reference["n_neighbours"]).all()
+        assert neighbours.results.neighbours.shape[0] == (reference["n_frames"])
+        assert neighbours.results.neighbours[0].shape == (reference["n_residues"], reference["n_residues"])
+        assert (np.sum(neighbours.results.neighbours[0].toarray(), axis=0) == reference["n_neighbours"]).all()
 
     def test_subset_lipids(self, universe):
         neighbours = Neighbours(universe, lipid_sel="name C", cutoff=10)
@@ -72,9 +72,12 @@ class TestNeighbours:
         }
         # fmt: on
 
-        assert neighbours.neighbours.shape[0] == (reference["n_frames"])
-        assert neighbours.neighbours[0].shape == (reference["n_residues"], reference["n_residues"])
-        assert_array_equal(np.sum(neighbours.neighbours[0].toarray(), axis=0), reference["n_neighbours"])
+        assert neighbours.results.neighbours.shape[0] == (reference["n_frames"])
+        assert neighbours.results.neighbours[0].shape == (reference["n_residues"], reference["n_residues"])
+        assert_array_equal(
+            np.sum(neighbours.results.neighbours[0].toarray(), axis=0),
+            reference["n_neighbours"],
+        )
 
 
 class TestNeighboursExceptions:

--- a/tests/lipyphilic/lib/test_order_parameter.py
+++ b/tests/lipyphilic/lib/test_order_parameter.py
@@ -31,8 +31,8 @@ class TestSCC:
             "scc": np.full((100, 1), fill_value=-0.5),  # all bonds are perpendicular to the z-axis
         }
 
-        assert scc.SCC.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(scc.SCC, reference["scc"])
+        assert scc.results.SCC.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(scc.results.SCC, reference["scc"])
 
     def test_SCC_normals_3D(self, universe):
         # The Scc should be the same whether the normal is the positive or negative z-axis
@@ -49,8 +49,8 @@ class TestSCC:
             "scc": np.full((100, 1), fill_value=-0.5),  # all bonds are perpendicular to the z-axis
         }
 
-        assert scc.SCC.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(scc.SCC, reference["scc"])
+        assert scc.results.SCC.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(scc.results.SCC, reference["scc"])
 
 
 class TestSCCWeightedAverage:
@@ -74,8 +74,8 @@ class TestSCCWeightedAverage:
             "scc": np.full((50, 1), fill_value=-0.5),  # all bonds are perpendicular to the z-axis
         }
 
-        assert scc.SCC.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(scc.SCC, reference["scc"])
+        assert scc.results.SCC.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(scc.results.SCC, reference["scc"])
 
     def test_SCC_weighted_average_different_tails(self, universe, sn1_scc):
         sn2_scc = SCC(universe, "name L")
@@ -88,8 +88,8 @@ class TestSCCWeightedAverage:
             "scc": np.full((100, 1), fill_value=-0.5),  # all bonds are perpendicular to the z-axis
         }
 
-        assert scc.SCC.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(scc.SCC, reference["scc"])
+        assert scc.results.SCC.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(scc.results.SCC, reference["scc"])
 
     def test_SCC_weighted_average_different_number_of_lipids(self, universe, sn1_scc):
         sn2_scc = SCC(universe, "name L C")
@@ -102,8 +102,8 @@ class TestSCCWeightedAverage:
             "scc": np.full((100, 1), fill_value=-0.5),  # all bonds are perpendicular to the z-axis
         }
 
-        assert scc.SCC.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(scc.SCC, reference["scc"])
+        assert scc.results.SCC.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(scc.results.SCC, reference["scc"])
 
 
 class TestSCCExceptions:
@@ -199,17 +199,17 @@ class TestSCCProjectSCC:
         scc_projection = scc.project_SCC()
 
         assert isinstance(scc_projection, ProjectionPlot)
-        assert_array_almost_equal(scc_projection.values, scc.SCC.mean())
+        assert_array_almost_equal(scc_projection.values, scc.results.SCC.mean())
 
     def test_filter_by(self, scc):
         scc_projection = scc.project_SCC(filter_by=[True])
 
-        assert_array_almost_equal(scc_projection.values, scc.SCC.mean())
+        assert_array_almost_equal(scc_projection.values, scc.results.SCC.mean())
 
     def test_filter_by_2D(self, scc):
         scc_projection = scc.project_SCC(filter_by=np.full((1, 25), fill_value=True))
 
-        assert_array_almost_equal(scc_projection.values, scc.SCC.mean())
+        assert_array_almost_equal(scc_projection.values, scc.results.SCC.mean())
 
     def test_filter_by_exception(self, scc):
         match = "The shape of `filter_by` must either be \\(n_lipids, n_frames\\) or \\(n_lipids\\)"

--- a/tests/lipyphilic/lib/test_registration.py
+++ b/tests/lipyphilic/lib/test_registration.py
@@ -31,8 +31,8 @@ class TestRegistration:
             "registration": 1,
         }
 
-        assert registration.registration.size == reference["n_frames"]
-        assert_array_almost_equal(registration.registration, reference["registration"])
+        assert registration.results.registration.size == reference["n_frames"]
+        assert_array_almost_equal(registration.results.registration, reference["registration"])
 
     def test_antiregistred(self, universe):
         registration = Registration(
@@ -48,8 +48,8 @@ class TestRegistration:
             "registration": -1,
         }
 
-        assert registration.registration.size == reference["n_frames"]
-        assert_array_almost_equal(registration.registration, reference["registration"])
+        assert registration.results.registration.size == reference["n_frames"]
+        assert_array_almost_equal(registration.results.registration, reference["registration"])
 
     def test_nbins100(self, universe):
         registration = Registration(
@@ -66,8 +66,8 @@ class TestRegistration:
             "registration": 1,
         }
 
-        assert registration.registration.size == reference["n_frames"]
-        assert_array_almost_equal(registration.registration, reference["registration"])
+        assert registration.results.registration.size == reference["n_frames"]
+        assert_array_almost_equal(registration.results.registration, reference["registration"])
 
     def test_nbins1000_sd0(self, universe):
         # The bins are 0.1 Anstrom wide, and gaussian_sd=0 means there is no spead
@@ -88,8 +88,8 @@ class TestRegistration:
             "registration": 0,
         }
 
-        assert registration.registration.size == reference["n_frames"]
-        assert_array_almost_equal(registration.registration, reference["registration"], decimal=4)
+        assert registration.results.registration.size == reference["n_frames"]
+        assert_array_almost_equal(registration.results.registration, reference["registration"], decimal=4)
 
     def test_filter_by_registered(self, universe):
         filter_by = np.zeros(100)
@@ -109,8 +109,8 @@ class TestRegistration:
             "registration": 1,
         }
 
-        assert registration.registration.size == reference["n_frames"]
-        assert_array_almost_equal(registration.registration, reference["registration"], decimal=4)
+        assert registration.results.registration.size == reference["n_frames"]
+        assert_array_almost_equal(registration.results.registration, reference["registration"], decimal=4)
 
     def test_filter_by_2D_registered(self, universe):
         filter_by = np.zeros(100)
@@ -130,8 +130,8 @@ class TestRegistration:
             "registration": 1,
         }
 
-        assert registration.registration.size == reference["n_frames"]
-        assert_array_almost_equal(registration.registration, reference["registration"], decimal=4)
+        assert registration.results.registration.size == reference["n_frames"]
+        assert_array_almost_equal(registration.results.registration, reference["registration"], decimal=4)
 
 
 class TestRegistrationExceptions:

--- a/tests/lipyphilic/lib/test_z_angles.py
+++ b/tests/lipyphilic/lib/test_z_angles.py
@@ -40,8 +40,8 @@ class TestZAngles:
         }
         # fmt: on
 
-        assert z_angles.z_angles.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(z_angles.z_angles, reference["z_angles"])
+        assert z_angles.results.z_angles.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(z_angles.results.z_angles, reference["z_angles"])
 
     def test_z_angles_radians(self, universe):
         z_angles = ZAngles(universe, **self.kwargs, rad=True)
@@ -65,8 +65,8 @@ class TestZAngles:
         }
         # fmt: on
 
-        assert z_angles.z_angles.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(z_angles.z_angles, np.deg2rad(reference["z_angles"]))
+        assert z_angles.results.z_angles.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(z_angles.results.z_angles, np.deg2rad(reference["z_angles"]))
 
 
 class TestZAnglesExceptions:

--- a/tests/lipyphilic/lib/test_z_positions.py
+++ b/tests/lipyphilic/lib/test_z_positions.py
@@ -35,8 +35,8 @@ class TestZPositions:
         # the lower leaflet (final 25 residues) cholesterols are at -10 Angstrom
         reference["z_positions"][25:] = -10
 
-        assert z_positions.z_positions.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_equal(z_positions.z_positions, reference["z_positions"])
+        assert z_positions.results.z_positions.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_equal(z_positions.results.z_positions, reference["z_positions"])
 
     def test_exceptions(self):
         universe_triclinic = MDAnalysis.Universe(TRICLINIC)
@@ -77,8 +77,8 @@ class TestZPositionsOneAtom:
         # the lower leaflet (final 25 residues) cholesterols are at -10 Angstrom
         reference["z_positions"][25:] = -10
 
-        assert z_positions.z_positions.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_equal(z_positions.z_positions, reference["z_positions"])
+        assert z_positions.results.z_positions.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_equal(z_positions.results.z_positions, reference["z_positions"])
 
 
 class TestZPositionsUndulating:
@@ -109,5 +109,5 @@ class TestZPositionsUndulating:
         # the lower leaflet (final 25 residues) cholesterols are at -10 Angstrom
         reference["z_positions"][25:] = -10
 
-        assert z_positions.z_positions.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_equal(z_positions.z_positions, reference["z_positions"])
+        assert z_positions.results.z_positions.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_equal(z_positions.results.z_positions, reference["z_positions"])

--- a/tests/lipyphilic/lib/test_z_thickness.py
+++ b/tests/lipyphilic/lib/test_z_thickness.py
@@ -27,8 +27,8 @@ class TestZThickness:
             "z_thickness": np.full((50, 1), fill_value=20),  # all lipids have a thickness of 20 Angstrom
         }
 
-        assert z_thickness.z_thickness.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_equal(z_thickness.z_thickness, reference["z_thickness"])
+        assert z_thickness.results.z_thickness.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_equal(z_thickness.results.z_thickness, reference["z_thickness"])
 
 
 class TestZThicknessAverage:
@@ -59,8 +59,8 @@ class TestZThicknessAverage:
         }
 
         assert isinstance(thickness, ZThickness)
-        assert thickness.z_thickness.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(thickness.z_thickness, reference["z_thickness"])
+        assert thickness.results.z_thickness.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(thickness.results.z_thickness, reference["z_thickness"])
 
     def test_ZThickness_average_different_tails(self, sn1_thickness, sn2_thickness):
         thickness = ZThickness.average(sn1_thickness, sn2_thickness)
@@ -71,8 +71,8 @@ class TestZThicknessAverage:
             "z_thickness": np.full((50, 1), fill_value=20),
         }
 
-        assert thickness.z_thickness.shape == (reference["n_residues"], reference["n_frames"])
-        assert_array_almost_equal(thickness.z_thickness, reference["z_thickness"])
+        assert thickness.results.z_thickness.shape == (reference["n_residues"], reference["n_frames"])
+        assert_array_almost_equal(thickness.results.z_thickness, reference["z_thickness"])
 
 
 class TestZThicknessAverageExceptions:


### PR DESCRIPTION
Fixes #60 

Changes made in this Pull Request:
 - use `mdanalysis.analysis.base.Results` for storing all results
 - all results stored in the `.results` attribute
 - all results can also be accessed via their original attributes (which are now properties)


PR Checklist
------------
 - [ ] Tests added and passing?
 - [ ] Docs added and building?
 - [ ] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
