### PR TITLE
Deprecate `lipyphilic.transformations.nojump`

### DIFF
--- a/docs/reference/analyses.rst
+++ b/docs/reference/analyses.rst
@@ -434,13 +434,11 @@ On-the-fly transformations :mod:`lipyphilic.transformations.transformations`
 **lipyphilic** contains a module for applying on-the-fly transformation to atomic coordinates
 while iterating over a trajectory. These are available in the module :mod:`lipyphilic.transformations.transformations`.
 
-There are three transformations available in **lipyphilic**:
+There are two transformations available in **lipyphilic**:
 
-1. | :class:`lipyphilic.transformations.transformations.nojump`, which prevents atoms from jumping across periodic
-   | boundaries. This is useful when calculating the lateral diffusion of lipids.
-2. | :class:`lipyphilic.transformations.transformations.center_membrane`, which can take a membrane that is split
+1. | :class:`lipyphilic.transformations.transformations.center_membrane`, which can take a membrane that is split
    | across periodic boundaries, make it whole and center it in the box.
-3. | :class:`lipyphilic.transformations.transformations.triclinic_to_orthorhombic`, which transforms triclinic coordinates
+2. | :class:`lipyphilic.transformations.transformations.triclinic_to_orthorhombic`, which transforms triclinic coordinates
    | into their orthorhombic representation.
 
 See :mod:`lipyphilic.transformations.transformations.` for full details on these transformations including how to apply

--- a/docs/reference/tutorials.rst
+++ b/docs/reference/tutorials.rst
@@ -28,9 +28,9 @@ We currently have tutorials on the following topics:
 5. | **Interleaflet registration**: This notebook shows how to calculate the interleaflet registration over
    | time. The example shows how to calculate the registration of |Lo| lipids across leaflets.
 
-6. | **Lateral diffusion**: Illustrates how to perform "nojump" trajectory unwrapping with LiPyphilic,
+6. | **Lateral diffusion**: Illustrates how to perform "nojump" trajectory unwrapping with MDAnalysis,
    | then use the unwrapped coordinates to calculate the mean-squared displacement and lateral
-   | diffusion coefficient of lipids in a membrane.
+   | diffusion coefficient of lipids in a membrane with LiPyphilic.
 
 7. | **Coarse-grained lipid order parameter**: Shows how to calculate the coarse-grained order
    | parameter, and how to create a two-dimensional projection of these values onto the membrane

--- a/src/lipyphilic/analysis/lateral_diffusion.py
+++ b/src/lipyphilic/analysis/lateral_diffusion.py
@@ -58,7 +58,7 @@ Warning
 -------
 
 Before using `lipyphilic.analysis.lateral_diffusion.MSD` you *must* ensure that the coordinates have
-been unwrapped using, for example, :class:`lipyphilic.transformations.nojump`.
+been unwrapped using, for example, :class:`MDAnalysis.transformations.NoJumo`.
 
 
 Example usage of :class:`MSD`

--- a/src/lipyphilic/analysis/lateral_diffusion.py
+++ b/src/lipyphilic/analysis/lateral_diffusion.py
@@ -58,7 +58,7 @@ Warning
 -------
 
 Before using `lipyphilic.analysis.lateral_diffusion.MSD` you *must* ensure that the coordinates have
-been unwrapped using, for example, :class:`MDAnalysis.transformations.NoJumo`.
+been unwrapped using, for example, :class:`MDAnalysis.transformations.NoJump`.
 
 
 Example usage of :class:`MSD`

--- a/src/lipyphilic/transformations/__init__.py
+++ b/src/lipyphilic/transformations/__init__.py
@@ -1,7 +1,6 @@
-from lipyphilic.transformations.transformations import center_membrane, nojump, triclinic_to_orthorhombic
+from lipyphilic.transformations.transformations import center_membrane, triclinic_to_orthorhombic
 
 __all__ = [
-    "nojump",
     "center_membrane",
     "triclinic_to_orthorhombic",
 ]

--- a/src/lipyphilic/transformations/__init__.py
+++ b/src/lipyphilic/transformations/__init__.py
@@ -1,6 +1,7 @@
-from lipyphilic.transformations.transformations import center_membrane, triclinic_to_orthorhombic
+from lipyphilic.transformations.transformations import center_membrane, nojump, triclinic_to_orthorhombic
 
 __all__ = [
     "center_membrane",
     "triclinic_to_orthorhombic",
+    "nojump",
 ]

--- a/src/lipyphilic/transformations/transformations.py
+++ b/src/lipyphilic/transformations/transformations.py
@@ -12,37 +12,6 @@ Trajectory transformations --- :mod:`lipyphilic.transformations.transformations`
 This module contains methods for applying on-the-fly trajectory transformations
 with MDAnalysis.
 
-Prevent atoms from jumping across periodic boundaries
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-:class:`nojump` can be used to prevent atoms from jumping across
-periodic boundaries. It is equivalent to using the
-`GROMACS <https://manual.gromacs.org/current/index.html>`__ command
-`trjconv <https://manual.gromacs.org/current/onlinehelp/gmx-trjconv.html>`__ with the flag
-`-pbc nojump`.
-
-The on-the-fly transformation can be added to your trajectory after loading it with
-MDAnalysis:
-
-.. code:: python
-
-  import MDAnalysis as mda
-  import lipyphilic as lpp
-
-  u = mda.Universe("production.tpr", "production.xtc")
-
-  ag = u.select_atoms("name GL1 GL2 ROH")
-
-  u.trajectory.add_transformations(lpp.transformations.nojump(ag))
-
-Upon adding this transformation to your trajectory, `lipyphilic` will determine at which frames
-each atom crosses a boundary, keeping a record of the net movement across each boundary. Then,
-every time a new frame is loaded into memory by `MDAnalysis` --- such as when you iterate over
-the trajectory --- the transformation is applied.
-
-This transformation is required when calculating the lateral diffusion of lipids in a membrane
-using, for example, :class:`lipyphilic.analysis.lateral_diffusion.MSD`. It can be used to remove the
-need to create an unwrapped trajectory using `GROMACS`.
 
 Fix membranes broken across periodic boundaries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -119,8 +88,8 @@ These analyses will fail with triclinic boxes - the `triclinic_to_orthorhombic` 
 *must* be applied to triclinic systems before these tools can be used.
 
 Another case that will fail with triclinic systems is the
-:class:`nojump` transformation -  this transformation
-can currently only unwrap coordinates for orthorhombic systems.
+:class:`center_membrane` transformation -  this transformation
+can currently center membranes in orthorhombic systems.
 
 See :class:`triclinic_to_orthorhombic` for the full list.
 
@@ -138,7 +107,6 @@ import numpy as np
 from tqdm.auto import tqdm
 
 __all__ = [
-    "nojump",
     "center_membrane",
     "triclinic_to_orthorhombic",
 ]

--- a/src/lipyphilic/transformations/transformations.py
+++ b/src/lipyphilic/transformations/transformations.py
@@ -131,6 +131,7 @@ See :class:`triclinic_to_orthorhombic` for the full list.
 """
 
 import pathlib
+import warnings
 
 import MDAnalysis as mda  # noqa: N813
 import numpy as np
@@ -157,6 +158,9 @@ class nojump:  # noqa: N801
 
     By default, atoms are only unwrapped in :math:`xy`, as it is assumed the membrane
     is a bilayer. To unwrap in all dimensions, :attr:`center_z` must also be set to `True`.
+
+     .. deprecated:: 0.11.0
+        Please use `MDAnalysis.transformations.NoJump` instead.
 
     """
 
@@ -195,6 +199,16 @@ class nojump:  # noqa: N801
         The current implementation of `nojump` can only unwrap coordinates in orthorhombic systems.
 
         """
+        _msg = (
+            "`lipyphilic.transformations.nojump` is deprecated and will be removed "
+            "in a later version. Please instead use `MDAnalysis.transformations.NoJump`."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         self.ag = ag
         self.nojump_xyz = np.array([nojump_x, nojump_y, nojump_z], dtype=bool)
         self._nojump_indices = self.nojump_xyz.nonzero()[0]


### PR DESCRIPTION
Related to #105 
Related to #113 

Changes made in this Pull Request:
 - deprecate `lipyphilic.transformations.nojump`
 - suggest use of `MDAnalysis.transformations.NoJump` instead


PR Checklist
------------
 - [ ] Tests added and passing?
 - [ ] Docs added and building?
 - [ ] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
