### PR TITLE
remove `triclinic_to_orthorhombic`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,8 @@ The analysis classes are designed with the same interface as those of MDAnalysis
 will be a breeze.
 
 Analysis tools in **lipyphilic** include: identifying sterol flip-flop events, calculating domain registration over time,
-and calculating local lipid compositions. **lipyphilic** also has three on-the-fly trajectory transformations to i) fix
-membranes split across periodic boundaries and ii) perform nojump coordinate unwrapping and iii) convert triclinic coordinates
-to their orthorhombic representation.
+and calculating local lipid compositions. **lipyphilic** also has an on-the-fly trajectory transformation to fix
+membranes split across periodic boundaries.
 
 These tools position **lipyphilic** as complementary to, rather than competing against, existing membrane analysis
 software such as `MemSurfer <https://github.com/LLNL/MemSurfer>`__ and `FatSlim <http://fatslim.github.io/>`__.

--- a/docs/reference/analyses.rst
+++ b/docs/reference/analyses.rst
@@ -434,12 +434,10 @@ On-the-fly transformations :mod:`lipyphilic.transformations.transformations`
 **lipyphilic** contains a module for applying on-the-fly transformation to atomic coordinates
 while iterating over a trajectory. These are available in the module :mod:`lipyphilic.transformations.transformations`.
 
-There are two transformations available in **lipyphilic**:
+There is currently one transformation available in **lipyphilic**:
 
 1. | :class:`lipyphilic.transformations.transformations.center_membrane`, which can take a membrane that is split
    | across periodic boundaries, make it whole and center it in the box.
-2. | :class:`lipyphilic.transformations.transformations.triclinic_to_orthorhombic`, which transforms triclinic coordinates
-   | into their orthorhombic representation.
 
-See :mod:`lipyphilic.transformations.transformations.` for full details on these transformations including how to apply
-them to your trajectory.
+See :mod:`lipyphilic.transformations.transformations.` for full details on this transformation including how to apply
+it to your trajectory.

--- a/src/lipyphilic/analysis/area_per_lipid.py
+++ b/src/lipyphilic/analysis/area_per_lipid.py
@@ -165,11 +165,7 @@ class AreaPerLipid(AnalysisBase):
         self.membrane = self.u.select_atoms(lipid_sel, updating=False)
 
         if not np.allclose(self.u.dimensions[3:], 90.0):
-            _msg = (
-                "AreaPerLipid requires an orthorhombic box. Please use the on-the-fly "
-                "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
-                "before calling AreaPerLipid"
-            )
+            _msg = "AreaPerLipid requires an orthorhombic box - triclinic systems are not supported."
             raise ValueError(_msg)
 
         if np.array(leaflets).ndim not in [1, 2]:

--- a/src/lipyphilic/analysis/memb_thickness.py
+++ b/src/lipyphilic/analysis/memb_thickness.py
@@ -186,11 +186,7 @@ class MembThickness(AnalysisBase):
         self.membrane = self.u.select_atoms(self.lipid_sel, updating=False)
 
         if not np.allclose(self.u.dimensions[3:], 90.0):
-            _msg = (
-                "MembThickness requires an orthorhombic box. Please use the on-the-fly "
-                "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
-                "before calling MembThickness",
-            )
+            _msg = "MembThickness requires an orthorhombic box - triclinic systems are not supported."
             raise ValueError(_msg)
 
         if np.array(leaflets).ndim not in [1, 2]:

--- a/src/lipyphilic/analysis/registration.py
+++ b/src/lipyphilic/analysis/registration.py
@@ -261,11 +261,7 @@ class Registration(AnalysisBase):
         self.membrane = self.u.select_atoms(f"({self.upper_sel}) or ({self.lower_sel})")
 
         if not np.allclose(self.u.dimensions[3:], 90.0):
-            _msg = (
-                "Registration requires an orthorhombic box. Please use the on-the-fly "
-                "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
-                "before calling Registration",
-            )
+            _msg = "Registration requires an orthorhombic box - triclinic systems are not supported."
             raise ValueError(_msg)
 
         if np.array(leaflets).ndim not in [1, 2]:

--- a/src/lipyphilic/analysis/z_angles.py
+++ b/src/lipyphilic/analysis/z_angles.py
@@ -137,11 +137,7 @@ class ZAngles(AnalysisBase):
         self.u = universe
 
         if not np.allclose(self.u.dimensions[3:], 90.0):
-            _msg = (
-                "ZAngles requires an orthorhombic box. Please use the on-the-fly "
-                "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
-                "before calling ZAngles",
-            )
+            _msg = "ZAngles requires an orthorhombic box - triclinic systems are not supported."
             raise ValueError(_msg)
 
         self.atom_A = self.u.select_atoms(atom_A_sel, updating=False)

--- a/src/lipyphilic/analysis/z_positions.py
+++ b/src/lipyphilic/analysis/z_positions.py
@@ -168,11 +168,7 @@ class ZPositions(AnalysisBase):
         self._height_atoms = self.u.select_atoms(height_sel, updating=False)
 
         if not np.allclose(self.u.dimensions[3:], 90.0):
-            _msg = (
-                "ZPositions requires an orthorhombic box. Please use the on-the-fly "
-                "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
-                "before calling ZPositions",
-            )
+            _msg = "ZPositions requires an orthorhombic box - triclinic systems are not supported."
             raise ValueError(_msg)
 
         # lipid species for which the height in z will be calculated

--- a/src/lipyphilic/analysis/z_thickness.py
+++ b/src/lipyphilic/analysis/z_thickness.py
@@ -134,11 +134,7 @@ class ZThickness(AnalysisBase):
         self.lipids = self.u.select_atoms(lipid_sel, updating=False)
 
         if not np.allclose(self.u.dimensions[3:], 90.0):
-            _msg = (
-                "ZThickness requires an orthorhombic box. Please use the on-the-fly "
-                "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
-                "before calling ZThickness",
-            )
+            _msg = "ZThickness requires an orthorhombic box - triclinic systems are not supported."
             raise ValueError(_msg)
 
         # For fancy slicing of atoms for each species

--- a/src/lipyphilic/leaflets/assign_leaflets.py
+++ b/src/lipyphilic/leaflets/assign_leaflets.py
@@ -362,9 +362,8 @@ class AssignLeaflets(AssignLeafletsBase):
 
         if not np.allclose(self.u.dimensions[3:], 90.0):
             _msg = (
-                "AssignLeaflets requires an orthorhombic box. Please use the on-the-fly "
-                "transformation :class:`lipyphilic.transformations.triclinic_to_orthorhombic` "
-                "before calling AssignLeaflets",
+                "AssignLeaflets requires an orthorhombic box - triclinic systems are not supported. "
+                "Please use :class:`lipyphilic.leaflets.AssignCurvedLeaflets` instead."
             )
             raise ValueError(_msg)
 

--- a/src/lipyphilic/transformations/__init__.py
+++ b/src/lipyphilic/transformations/__init__.py
@@ -1,7 +1,6 @@
-from lipyphilic.transformations.transformations import center_membrane, nojump, triclinic_to_orthorhombic
+from lipyphilic.transformations.transformations import center_membrane, nojump
 
 __all__ = [
     "center_membrane",
-    "triclinic_to_orthorhombic",
     "nojump",
 ]

--- a/src/lipyphilic/transformations/transformations.py
+++ b/src/lipyphilic/transformations/transformations.py
@@ -137,11 +137,7 @@ class nojump:  # noqa: N801
         self._nojump_indices = self.nojump_xyz.nonzero()[0]
 
         if not np.allclose(self.ag.universe.dimensions[3:], 90.0):
-            _msg = (
-                "nojump requires an orthorhombic box. Please use the on-the-fly "
-                "transformation `lipyphilic.transformations.triclinic_to_orthorhombic` "
-                "before calling nojump",
-            )
+            _msg = "nojump requires an orthorhombic box - triclinic systems are not supported."
             raise ValueError(_msg)
 
         self.ref_pos = ag.positions
@@ -321,7 +317,7 @@ class center_membrane:  # noqa: N801
         self.min_diff = min_diff
 
         if not np.allclose(self.membrane.universe.dimensions[3:], 90.0):
-            _msg = "cannot apply the transformation `center_membrane` as it requires an orthorhombic box."
+            _msg = "center_membrane requires an orthorhombic box - triclinic systems are not supported."
             raise ValueError(_msg)
 
     def __call__(self, ts):

--- a/tests/lipyphilic/analysis/transformations/test_transformations.py
+++ b/tests/lipyphilic/analysis/transformations/test_transformations.py
@@ -89,7 +89,7 @@ class TestNoJump:
     def test_exceptions(self):
         universe_triclinic = MDAnalysis.Universe(TRICLINIC)
 
-        match = "nojump requires an orthorhombic box. Please use the on-the-fly"
+        match = "nojump requires an orthorhombic box"
         with pytest.raises(ValueError, match=match):
             universe_triclinic.trajectory.add_transformations(
                 nojump(ag=universe_triclinic.atoms),
@@ -204,7 +204,7 @@ class TestCenterMembrane:
     def test_exceptions(self):
         universe_triclinic = MDAnalysis.Universe(TRICLINIC)
 
-        match = "center_membrane requires an orthorhombic box. Please use the on-the-fly"
+        match = "center_membrane requires an orthorhombic box"
         with pytest.raises(ValueError, match=match):
             universe_triclinic.trajectory.add_transformations(
                 center_membrane(ag=universe_triclinic.atoms),

--- a/tests/lipyphilic/analysis/transformations/test_transformations.py
+++ b/tests/lipyphilic/analysis/transformations/test_transformations.py
@@ -1,7 +1,7 @@
 import MDAnalysis
 import MDAnalysis.transformations.wrap
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_almost_equal, assert_raises
+from numpy.testing import assert_array_almost_equal, assert_raises
 import pytest
 
 from lipyphilic._simple_systems.simple_systems import (
@@ -13,7 +13,6 @@ from lipyphilic._simple_systems.simple_systems import (
 from lipyphilic.transformations import (
     center_membrane,
     nojump,
-    triclinic_to_orthorhombic,
 )
 
 
@@ -209,53 +208,4 @@ class TestCenterMembrane:
         with pytest.raises(ValueError, match=match):
             universe_triclinic.trajectory.add_transformations(
                 center_membrane(ag=universe_triclinic.atoms),
-            )
-
-
-class TestTriclinicToOrthorhombic:
-    def test_no_transformation(self):
-        universe = MDAnalysis.Universe(TRICLINIC)
-        pos = universe.atoms.positions
-        wrapped_pos = universe.atoms.wrap()
-
-        # Second and third atoms are currently outside the unit cell
-        assert_raises(
-            AssertionError,
-            assert_array_almost_equal,
-            pos,
-            wrapped_pos,
-            decimal=5,
-        )
-
-    def test_transform_frame(self):
-        universe = MDAnalysis.Universe(TRICLINIC)
-        atoms = universe.atoms
-        universe.trajectory.add_transformations(
-            triclinic_to_orthorhombic(ag=atoms),
-        )
-
-        # Check distance between two atoms
-        # Below distance calculated using `mda.lib.distances.distance_array`
-        triclinic_dist = 65.57408
-
-        atom1_pos, atom2_pos, _ = universe.atoms.positions
-        orthorhombic_dist = np.linalg.norm(atom1_pos - atom2_pos)
-
-        assert_almost_equal(triclinic_dist, orthorhombic_dist, decimal=5)
-
-        # Check all atoms are in the unit cell
-        pos = universe.atoms.positions
-        wrapped_pos = universe.atoms.wrap()
-
-        assert_array_almost_equal(pos, wrapped_pos, decimal=5)
-
-    def test_Exceptions(self):
-        universe = MDAnalysis.Universe(TRICLINIC)
-        atoms = universe.atoms
-
-        match = "No other transformation should be applied "
-        with pytest.raises(ValueError, match=match):
-            universe.trajectory.add_transformations(
-                MDAnalysis.transformations.wrap(ag=atoms),
-                triclinic_to_orthorhombic(ag=atoms),
             )

--- a/tests/lipyphilic/lib/test_area_per_lipid.py
+++ b/tests/lipyphilic/lib/test_area_per_lipid.py
@@ -149,7 +149,7 @@ class TestAreaPerLipidExceptions:
             areas.run()
 
         universe_triclinic = MDAnalysis.Universe(TRICLINIC)
-        match = "AreaPerLipid requires an orthorhombic box. Please use the on-the-fly"
+        match = "AreaPerLipid requires an orthorhombic box"
         with pytest.raises(ValueError, match=match):
             areas = AreaPerLipid(
                 universe=universe_triclinic,

--- a/tests/lipyphilic/lib/test_assign_leaflets.py
+++ b/tests/lipyphilic/lib/test_assign_leaflets.py
@@ -115,7 +115,7 @@ class TestAssignLeafletsExceptions:
             )
 
         universe_triclinic = MDAnalysis.Universe(TRICLINIC)
-        match = "AssignLeaflets requires an orthorhombic box. Please use the on-the-fly"
+        match = "AssignLeaflets requires an orthorhombic box"
         with pytest.raises(ValueError, match=match):
             lpp.AssignLeaflets(
                 universe=universe_triclinic,

--- a/tests/lipyphilic/lib/test_memb_thickness.py
+++ b/tests/lipyphilic/lib/test_memb_thickness.py
@@ -144,7 +144,7 @@ class TestMembThicknessExceptions:
             areas.run()
 
         universe_triclinic = MDAnalysis.Universe(TRICLINIC)
-        match = "MembThickness requires an orthorhombic box. Please use the on-the-fly"
+        match = "MembThickness requires an orthorhombic box"
         with pytest.raises(ValueError, match=match):
             MembThickness(
                 universe=universe_triclinic,

--- a/tests/lipyphilic/lib/test_registration.py
+++ b/tests/lipyphilic/lib/test_registration.py
@@ -198,7 +198,7 @@ class TestRegistrationExceptions:
             )
 
         universe_triclinic = MDAnalysis.Universe(TRICLINIC)
-        match = "Registration requires an orthorhombic box. Please use the on-the-fly"
+        match = "Registration requires an orthorhombic box"
         with pytest.raises(ValueError, match=match):
             Registration(
                 universe=universe_triclinic,

--- a/tests/lipyphilic/lib/test_z_angles.py
+++ b/tests/lipyphilic/lib/test_z_angles.py
@@ -89,7 +89,7 @@ class TestZAnglesExceptions:
             )
 
         universe_triclinic = MDAnalysis.Universe(TRICLINIC)
-        match = "ZAngles requires an orthorhombic box. Please use the on-the-fly"
+        match = "ZAngles requires an orthorhombic box"
         with pytest.raises(ValueError, match=match):
             ZAngles(
                 universe=universe_triclinic,

--- a/tests/lipyphilic/lib/test_z_positions.py
+++ b/tests/lipyphilic/lib/test_z_positions.py
@@ -40,7 +40,7 @@ class TestZPositions:
 
     def test_exceptions(self):
         universe_triclinic = MDAnalysis.Universe(TRICLINIC)
-        match = "ZPositions requires an orthorhombic box. Please use the on-the-fly"
+        match = "ZPositions requires an orthorhombic box"
         with pytest.raises(ValueError, match=match):
             ZPositions(
                 universe=universe_triclinic,

--- a/tests/lipyphilic/lib/test_z_thickness.py
+++ b/tests/lipyphilic/lib/test_z_thickness.py
@@ -111,7 +111,7 @@ class TestZThicknessAverageExceptions:
             ZThickness.average(sn1_thickness, sn2_thickness)
 
         universe_triclinic = MDAnalysis.Universe(TRICLINIC)
-        match = "ZThickness requires an orthorhombic box. Please use the on-the-fly"
+        match = "ZThickness requires an orthorhombic box"
         with pytest.raises(ValueError, match=match):
             ZThickness(
                 universe=universe_triclinic,


### PR DESCRIPTION
Changes made in this Pull Request:
 - remove the `triclinic_to_orthorhombic` transformation - the distance between atoms changes after applying the transformation, and so results will be inaccurate
 - raise an error if a triclinic system is used in an analysis/transformation that requires orthorhombic boxes
 - remove mention of triclinic_to_orthorhombic from the docs


PR Checklist
------------
 - [ ] Tests added and passing?
 - [ ] Docs added and building?
 - [ ] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
