### PR TITLE
Single source for package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
     "Programming Language :: Rust",
     'Topic :: Scientific/Engineering'
 ]
-version = "0.11.0.dev"
 dependencies = [
     "attrs",
     "numpy",
@@ -100,7 +99,6 @@ omit = [
     "*/base.py",
     "src/lipyphilic/__init__.py",
     "src/lipyphilic/lib/__init__.py",
-    "src/lipyphilic/_version.py",
     "rust/"
 ]
 exclude_lines = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lipyphilic"
-version = "0.1.0"
+version = "0.11.0-dev0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -45,6 +45,7 @@ fn molecule_flip_flop(
 #[pymodule]
 fn _lipyferric(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add("version", env!("CARGO_PKG_VERSION"))?;
     m.add_function(wrap_pyfunction!(molecule_flip_flop, m)?)?;
     Ok(())
 }

--- a/src/lipyphilic/__init__.py
+++ b/src/lipyphilic/__init__.py
@@ -1,4 +1,6 @@
-__version__ = version = "0.11.0.dev"
+from ._lipyferric import __version__
+
+__version__ = version = __version__.replace("-", ".")  # Rust uses X.Y-dev0 but Python X.Y.dev0
 __version_tuple__ = version_tuple = tuple(version.split("."))
 
 from lipyphilic import (


### PR DESCRIPTION
- define the version in a single place (`rust/Cargo.toml`)]
- Also account for difference in specifying dev version between Rust and Python (`X.Y-dev0` vs `X.Y.dev0`)


PR Checklist
------------
 - [ ] Tests added and passing?
 - [ ] Docs added and building?
 - [ ] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
