### PR TITLE
Add deprecation warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,3 @@
-==========================
-WARNING - BREAKING CHANGES
-==========================
-
-I am currently working on a 1.0 release of ``lipyphilic`` and **there will be a lot of breaking changes to the API**. This is because many of the modules will be moved from ``lipyphilic.lib`` to a new location ``lipyphilic.analysis``.
-
-However, the interface for classes / functions will mostly be unchanged and so you should be able to use them as before after changing your imports.
-
-Most of the other changes will be to internal code or modernising the packaging and testing side of things.
-
 ==========
 LiPyphilic
 ==========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "numpy",
     "scipy",
     "pandas",
+    "matplotlib < 3.8",
     "mdanalysis",
     "freud-analysis",
     "tidynamics",

--- a/src/lipyphilic/lib/area_per_lipid.py
+++ b/src/lipyphilic/lib/area_per_lipid.py
@@ -1,0 +1,36 @@
+import warnings
+
+import lipyphilic as lpp
+
+__all__ = []
+
+_msg = (
+    "The module `lipyphilic.lib.area_per_lipid` is deprecated and will be removed "
+    "in a later version. Please use `lipyphilic.analysis.area_per_lipid` instead."
+)
+warnings.warn(
+    _msg,
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class AreaPerLipid:
+    """This class is deprecated. Please use `lipyphilic.analysis.AreaPerLipid instead`."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        _msg = (
+            "`lipyphilic.lib.area_per_lipid.AreaPerLipid` is deprecated and will be removed "
+            "in a later version. Please use `lipyphilic.analysis.AreaPerLipid` instead."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return lpp.analysis.AreaPerLipid(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/lib/assign_leaflets.py
+++ b/src/lipyphilic/lib/assign_leaflets.py
@@ -1,5 +1,7 @@
 import warnings
 
+import lipyphilic as lpp
+
 __all__ = []
 
 _msg = (
@@ -31,6 +33,8 @@ class AssignLeaflets:
             stacklevel=2,
         )
 
+        return lpp.AssignLeaflets(*args, **kwargs)  # noqa:  PLE0101
+
 
 class AssignCurvedLeaflets:
     """This class is deprecated. Please use `lipyphilic.AssignCurvedLeaflets instead.`"""
@@ -42,10 +46,12 @@ class AssignCurvedLeaflets:
     ):
         _msg = (
             "`lipyphilic.lib.assign_leaflets.AssignCurvedLeaflets` is deprecated and will be removed "
-            "in a later version. Please instead use `lipyphilic.AssignLeaflets` instead."
+            "in a later version. Please instead use `lipyphilic.AssignCurvedLeaflets` instead."
         )
         warnings.warn(
             _msg,
             DeprecationWarning,
             stacklevel=2,
         )
+
+        return lpp.AssignCurvedLeaflets(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/lib/assign_leaflets.py
+++ b/src/lipyphilic/lib/assign_leaflets.py
@@ -25,7 +25,7 @@ class AssignLeaflets:
     ):
         _msg = (
             "`lipyphilic.lib.assign_leaflets.AssignLeaflets` is deprecated and will be removed "
-            "in a later version. Please instead use `lipyphilic.AssignLeaflets` instead."
+            "in a later version. Please use `lipyphilic.AssignLeaflets` instead."
         )
         warnings.warn(
             _msg,
@@ -46,7 +46,7 @@ class AssignCurvedLeaflets:
     ):
         _msg = (
             "`lipyphilic.lib.assign_leaflets.AssignCurvedLeaflets` is deprecated and will be removed "
-            "in a later version. Please instead use `lipyphilic.AssignCurvedLeaflets` instead."
+            "in a later version. Please use `lipyphilic.AssignCurvedLeaflets` instead."
         )
         warnings.warn(
             _msg,

--- a/src/lipyphilic/lib/flip_flop.py
+++ b/src/lipyphilic/lib/flip_flop.py
@@ -1,0 +1,36 @@
+import warnings
+
+import lipyphilic as lpp
+
+__all__ = []
+
+_msg = (
+    "The module `lipyphilic.lib.flip_flop` is deprecated and will be removed "
+    "in a later version. Please use `lipyphilic.analysis.flip_flop` instead."
+)
+warnings.warn(
+    _msg,
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class FlipFlop:
+    """The class is deprecated. Please use `lipyphilic.analysis.FlipFlop instead`."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        _msg = (
+            "`lipyphilic.lib.flip_flop.FlipFlop` is deprecated and will be removed "
+            "in a later version. Please use `lipyphilic.analysis.FlipFlop` instead."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return lpp.analysis.FlipFlop(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/lib/lateral_diffusion.py
+++ b/src/lipyphilic/lib/lateral_diffusion.py
@@ -1,0 +1,36 @@
+import warnings
+
+import lipyphilic as lpp
+
+__all__ = []
+
+_msg = (
+    "The module `lipyphilic.lib.lateral_diffusion` is deprecated and will be removed "
+    "in a later version. Please use `lipyphilic.analysis.lateral_diffusion` instead."
+)
+warnings.warn(
+    _msg,
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class MSD:
+    """The class is deprecated. Please use `lipyphilic.analysis.MSD instead`."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        _msg = (
+            "`lipyphilic.lib.lateral_diffusion.MSD` is deprecated and will be removed "
+            "in a later version. Please use `lipyphilic.analysis.MSD` instead."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return lpp.analysis.MSD(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/lib/memb_thickness.py
+++ b/src/lipyphilic/lib/memb_thickness.py
@@ -1,0 +1,36 @@
+import warnings
+
+import lipyphilic as lpp
+
+__all__ = []
+
+_msg = (
+    "The module `lipyphilic.lib.memb_thickness` is deprecated and will be removed "
+    "in a later version. Please use `lipyphilic.analysis.memb_thickness` instead."
+)
+warnings.warn(
+    _msg,
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class MembThickness:
+    """The class is deprecated. Please use `lipyphilic.analysis.MembThickness instead`."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        _msg = (
+            "`lipyphilic.lib.memb_thickness.MembThickness` is deprecated and will be removed "
+            "in a later version. Please use `lipyphilic.analysis.MembThickness` instead."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return lpp.analysis.MembThickness(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/lib/neighbours.py
+++ b/src/lipyphilic/lib/neighbours.py
@@ -1,0 +1,36 @@
+import warnings
+
+import lipyphilic as lpp
+
+__all__ = []
+
+_msg = (
+    "The module `lipyphilic.lib.neighbours` is deprecated and will be removed "
+    "in a later version. Please use `lipyphilic.analysis.neighbours` instead."
+)
+warnings.warn(
+    _msg,
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class Neighbours:
+    """The class is deprecated. Please use `lipyphilic.analysis.Neighbours instead`."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        _msg = (
+            "`lipyphilic.lib.neighbours.Neighbours` is deprecated and will be removed "
+            "in a later version. Please use `lipyphilic.analysis.Neighbours` instead."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return lpp.analysis.Neighbours(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/lib/order_parameter.py
+++ b/src/lipyphilic/lib/order_parameter.py
@@ -1,0 +1,36 @@
+import warnings
+
+import lipyphilic as lpp
+
+__all__ = []
+
+_msg = (
+    "The module `lipyphilic.lib.order_parameter` is deprecated and will be removed "
+    "in a later version. Please use `lipyphilic.analysis.order_parameter` instead."
+)
+warnings.warn(
+    _msg,
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class SCC:
+    """The class is deprecated. Please use `lipyphilic.analysis.SCC instead`."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        _msg = (
+            "`lipyphilic.lib.order_parameter.SCC` is deprecated and will be removed "
+            "in a later version. Please use `lipyphilic.analysis.SCC` instead."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return lpp.analysis.SCC(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/lib/plotting.py
+++ b/src/lipyphilic/lib/plotting.py
@@ -25,7 +25,7 @@ class ProjectionPlot:
     ):
         _msg = (
             "`lipyphilic.lib.plotting.ProjectionPlot` is deprecated and will be removed "
-            "in a later version. Please instead use `lipyphilic.plotting.ProjectionPlot` instead."
+            "in a later version. Please use `lipyphilic.plotting.ProjectionPlot` instead."
         )
         warnings.warn(
             _msg,
@@ -46,7 +46,7 @@ class JointDensity:
     ):
         _msg = (
             "`lipyphilic.lib.plotting.JointDensity` is deprecated and will be removed "
-            "in a later version. Please instead use `lipyphilic.plotting.JointDensity` instead."
+            "in a later version. Please use `lipyphilic.plotting.JointDensity` instead."
         )
         warnings.warn(
             _msg,

--- a/src/lipyphilic/lib/plotting.py
+++ b/src/lipyphilic/lib/plotting.py
@@ -1,5 +1,7 @@
 import warnings
 
+import lipyphilic as lpp
+
 __all__ = []
 
 _msg = (
@@ -31,6 +33,8 @@ class ProjectionPlot:
             stacklevel=2,
         )
 
+        return lpp.plotting.ProjectionPlot(*args, **kwargs)  # noqa:  PLE0101
+
 
 class JointDensity:
     """This class is deprecated. Please use `lipyphilic.plotting.JointDensity` instead.`"""
@@ -49,3 +53,5 @@ class JointDensity:
             DeprecationWarning,
             stacklevel=2,
         )
+
+        return lpp.plotting.JointDensity(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/lib/registration.py
+++ b/src/lipyphilic/lib/registration.py
@@ -1,0 +1,36 @@
+import warnings
+
+import lipyphilic as lpp
+
+__all__ = []
+
+_msg = (
+    "The module `lipyphilic.lib.registration` is deprecated and will be removed "
+    "in a later version. Please use `lipyphilic.analysis.registration` instead."
+)
+warnings.warn(
+    _msg,
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class Registration:
+    """The class is deprecated. Please use `lipyphilic.analysis.Registration instead`."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        _msg = (
+            "`lipyphilic.lib.registration.Registration` is deprecated and will be removed "
+            "in a later version. Please use `lipyphilic.analysis.Registration` instead."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return lpp.analysis.Registration(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/lib/z_angles.py
+++ b/src/lipyphilic/lib/z_angles.py
@@ -1,0 +1,36 @@
+import warnings
+
+import lipyphilic as lpp
+
+__all__ = []
+
+_msg = (
+    "The module `lipyphilic.lib.z_angles` is deprecated and will be removed "
+    "in a later version. Please use `lipyphilic.analysis.z_angles` instead."
+)
+warnings.warn(
+    _msg,
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class ZAngles:
+    """The class is deprecated. Please use `lipyphilic.analysis.ZAngles instead`."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        _msg = (
+            "`lipyphilic.lib.z_angles.ZAngles` is deprecated and will be removed "
+            "in a later version. Please use `lipyphilic.analysis.ZAngles` instead."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return lpp.analysis.ZAngles(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/lib/z_positions.py
+++ b/src/lipyphilic/lib/z_positions.py
@@ -1,0 +1,36 @@
+import warnings
+
+import lipyphilic as lpp
+
+__all__ = []
+
+_msg = (
+    "The module `lipyphilic.lib.z_positions` is deprecated and will be removed "
+    "in a later version. Please use `lipyphilic.analysis.z_positions` instead."
+)
+warnings.warn(
+    _msg,
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class ZPositions:
+    """The class is deprecated. Please use `lipyphilic.analysis.ZPositions instead`."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        _msg = (
+            "`lipyphilic.lib.z_positions.ZPositions` is deprecated and will be removed "
+            "in a later version. Please use `lipyphilic.analysis.ZPositions` instead."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return lpp.analysis.ZPositions(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/lib/z_thickness.py
+++ b/src/lipyphilic/lib/z_thickness.py
@@ -1,0 +1,36 @@
+import warnings
+
+import lipyphilic as lpp
+
+__all__ = []
+
+_msg = (
+    "The module `lipyphilic.lib.z_thickness` is deprecated and will be removed "
+    "in a later version. Please use `lipyphilic.analysis.z_thickness` instead."
+)
+warnings.warn(
+    _msg,
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class ZThickness:
+    """The class is deprecated. Please use `lipyphilic.analysis.ZThickness instead`."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        _msg = (
+            "`lipyphilic.lib.z_thickness.ZThickness` is deprecated and will be removed "
+            "in a later version. Please use `lipyphilic.analysis.ZThickness` instead."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return lpp.analysis.ZThickness(*args, **kwargs)  # noqa:  PLE0101

--- a/src/lipyphilic/transformations/transformations.py
+++ b/src/lipyphilic/transformations/transformations.py
@@ -51,7 +51,6 @@ Note
 
 
 .. autoclass:: nojump
-.. autoclass:: center_membrane
 
 """
 
@@ -65,6 +64,21 @@ from tqdm.auto import tqdm
 __all__ = [
     "center_membrane",
 ]
+
+
+class triclinic_to_orthorhombic:  # noqa: N801
+    """The class is deprecated and has been removed as its usage leads to incorrect results."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        _msg = (
+            "`lipyphilic.transformations.triclinic_to_orthorhombic` is deprecated and has been removed "
+            "as its usage leads to incorrect results."
+        )
+        raise NotImplementedError(_msg)
 
 
 class nojump:  # noqa: N801


### PR DESCRIPTION
Changes made in this Pull Request:
 - Add deprecation warning to all classes that have moved or will be removed
 - Remove warning from readme about breaking changes
 - Pin `matplotlib < 3.8` due to [changes to `CounterSet`](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.0.html#contourset-is-now-a-single-collection)


PR Checklist
------------
 - [ ] Tests added and passing?
 - [ ] Docs added and building?
 - [ ] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
