### PR TITLE
use pypa/gh-action-pypi-publish instead of PyO3/maturin-action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,17 +119,15 @@ jobs:
           skip-existing: true
 
   release:
-    name: Pulish to PyPI if upload to Test PyPI was successful
+    name: Publish to PyPI if upload to Test PyPI was successful
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux, windows, macos, sdist, release-test]
+    needs: [release-test]
     steps:
       - uses: actions/download-artifact@v3
         with:
           name: wheels
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          command: upload
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: ./


### PR DESCRIPTION
Changes made in this Pull Request:
 - use `pypa/gh-action-pypi-publish` instead of `PyO3/maturin-action` for uploading to PyPI


PR Checklist
------------
 - [ ] Tests added and passing?
 - [ ] Docs added and building?
 - [ ] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
