### PR TITLE
Fixes #143, return_surface and return_midpoint

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,4 @@ Authors (chronological)
 * Paul Smith
 * Raquel Lopez-Rios
 * David Goh
+* Rubén Chaves

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,35 +42,40 @@ To set up `lipyphilic` for local development:
     conda create -n lipyphilic-dev -c conda-forge python=3.10 pip
     conda activate lipyphilic-dev
 
-2. Fork `lipyphilic <https://github.com/p-j-smith/lipyphilic>`_
+2. Install and activate Rust::
+
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+    source $HOME/.cargo/env
+
+3. Fork `lipyphilic <https://github.com/p-j-smith/lipyphilic>`_
    (look for the "Fork" button).
 
-3. Clone your fork locally::
+4. Clone your fork locally::
 
     git clone git@github.com:YOURGITHUBNAME/lipyphilic.git
 
-4. Install an editible version of `lipyphilic` along with its development dependencies:
+5. Install an editible version of `lipyphilic` along with its development dependencies:
 
     cd lipyphilic
     python -m pip install -e ".[dev]"
 
-4. Create a branch for local development::
+6. Create a branch for local development::
 
     git checkout -b name-of-your-bugfix-or-feature
 
    Now you can make your changes locally.
 
-5. When you're done making changes run all the checks and docs builder with `tox <https://tox.readthedocs.io/en/latest/install.html>`_ one command::
+7. When you're done making changes run all the checks and docs builder with `tox <https://tox.readthedocs.io/en/latest/install.html>`_ one command::
 
     tox
 
-6. Commit your changes and push your branch to GitHub::
+8. Commit your changes and push your branch to GitHub::
 
     git add .
     git commit -m "Your detailed description of your changes."
     git push origin name-of-your-bugfix-or-feature
 
-7. Submit a pull request through the GitHub website.
+9. Submit a pull request through the GitHub website.
 
 Pull Request Guidelines
 -----------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,7 +42,7 @@ To set up `lipyphilic` for local development:
     conda create -n lipyphilic-dev -c conda-forge python=3.10 pip
     conda activate lipyphilic-dev
 
-2. Install and activate Rust::
+2. Install and activate `Rust <https://www.rust-lang.org/tools/install>`_::
 
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     source $HOME/.cargo/env

--- a/src/lipyphilic/analysis/area_per_lipid.py
+++ b/src/lipyphilic/analysis/area_per_lipid.py
@@ -313,7 +313,7 @@ class AreaPerLipid(AnalysisBase):
         return areas
 
     def _get_area_per_lipid(self, atoms, atom_areas):
-        """Calclate the area per lipid given the areas of every Voronoi cell in a tessellation.
+        """Calculate the area per lipid given the areas of every Voronoi cell in a tessellation.
 
         This involves summing contributions from each atom of a given lipid.
 

--- a/src/lipyphilic/analysis/memb_thickness.py
+++ b/src/lipyphilic/analysis/memb_thickness.py
@@ -285,7 +285,7 @@ class MembThickness(AnalysisBase):
         self.results.memb_thickness[self._frame_index] = thickness
 
         if self._return_surface:
-            self.memb_thickness_grid[self._frame_index] = upper_surface - lower_surface
+            self.memb_thickness_grid[self._frame_index] = upper_surface - lower_surface if self.n_bins > 1 else thickness
 
     def _interpolate(self, surface):
         """Interpolate the leaflet intrinsic surface.

--- a/src/lipyphilic/analysis/memb_thickness.py
+++ b/src/lipyphilic/analysis/memb_thickness.py
@@ -169,7 +169,8 @@ class MembThickness(AnalysisBase):
             of higher-resolution grids. The default is False.
         return_surface : bool, optional
             If True, the height of the bilayer at grid point at each frame is returned as
-            numpy ndarray. The default is False.
+            numpy ndarray. The 2D grid will be stored in self.memb_thickness_grid. The
+            default is False.
 
         Tip
         ---

--- a/src/lipyphilic/analysis/memb_thickness.py
+++ b/src/lipyphilic/analysis/memb_thickness.py
@@ -277,7 +277,7 @@ class MembThickness(AnalysisBase):
             lower_surface = self._interpolate(lower_surface)
 
         thickness = (
-            np.nanmean(upper_surface - lower_surface)
+            np.mean(upper_surface - lower_surface)
             if self.n_bins > 1
             else (upper_surface - lower_surface)[0, 0]
         )

--- a/src/lipyphilic/analysis/memb_thickness.py
+++ b/src/lipyphilic/analysis/memb_thickness.py
@@ -277,7 +277,7 @@ class MembThickness(AnalysisBase):
             lower_surface = self._interpolate(lower_surface)
 
         thickness = (
-            np.mean(upper_surface - lower_surface)
+            np.nanmean(upper_surface - lower_surface)
             if self.n_bins > 1
             else (upper_surface - lower_surface)[0, 0]
         )

--- a/src/lipyphilic/analysis/memb_thickness.py
+++ b/src/lipyphilic/analysis/memb_thickness.py
@@ -210,11 +210,16 @@ class MembThickness(AnalysisBase):
         self._interpolate_surfaces = interpolate
         self._return_surface = return_surface
         self.results.memb_thickness = None
+        self.results.memb_thickness_grid = None
 
     @property
     def memb_thickness(self):
         return self.results.memb_thickness
 
+    @property
+    def memb_thickness_grid(self):
+        return self.results.memb_thickness_grid
+    
     def _prepare(self):
         if (self.leaflets.ndim == 2) and (self.leaflets.shape[1] != self.n_frames):
             _msg = "The frames to analyse must be identical to those used in assigning lipids to leaflets."
@@ -224,7 +229,7 @@ class MembThickness(AnalysisBase):
         self.results.memb_thickness = np.full(self.n_frames, fill_value=np.NaN)
 
         if self._return_surface:
-            self.memb_thickness_grid = np.full(
+            self.results.memb_thickness_grid = np.full(
                 (self.n_frames, self.n_bins, self.n_bins),
                 fill_value=np.NaN,
             )
@@ -285,7 +290,7 @@ class MembThickness(AnalysisBase):
         self.results.memb_thickness[self._frame_index] = thickness
 
         if self._return_surface:
-            self.memb_thickness_grid[self._frame_index] = upper_surface - lower_surface if self.n_bins > 1 else thickness
+            self.results.memb_thickness_grid[self._frame_index] = upper_surface - lower_surface if self.n_bins > 1 else thickness
 
     def _interpolate(self, surface):
         """Interpolate the leaflet intrinsic surface.

--- a/src/lipyphilic/analysis/order_parameter.py
+++ b/src/lipyphilic/analysis/order_parameter.py
@@ -215,7 +215,7 @@ class SCC(AnalysisBase):
         normals = np.array(normals)
         if normals.ndim not in [0, 3]:
             _msg = (
-                "'normals' must be a 3D array containing local membrane normals of each lipi at each frame."
+                "'normals' must be a 3D array containing local membrane normals of each lipid at each frame."
             )
             raise ValueError(_msg)
 

--- a/src/lipyphilic/analysis/z_positions.py
+++ b/src/lipyphilic/analysis/z_positions.py
@@ -188,12 +188,17 @@ class ZPositions(AnalysisBase):
 
         self.n_bins = n_bins
         self.results.z_positions = None
+        self.results.memb_midpoint = None
         self._return_midpoint = return_midpoint
 
     @property
     def z_positions(self):
         return self.results.z_positions
 
+    @property
+    def memb_midpoint(self):
+        return self.results.memb_midpoint
+    
     def _prepare(self):
         # Output array
         self.results.z_positions = np.full(
@@ -202,7 +207,7 @@ class ZPositions(AnalysisBase):
         )
 
         if self._return_midpoint:
-            self.memb_midpoint = np.full(
+            self.results.memb_midpoint = np.full(
                 (self.n_frames, self.n_bins, self.n_bins),
                 fill_value=np.NaN)
 
@@ -231,7 +236,7 @@ class ZPositions(AnalysisBase):
             expand_binnumbers=True,
         )
         if self._return_midpoint:
-            self.memb_midpoint[self._frame_index] = memb_midpoint_xy.statistic if self.n_bins > 1 else memb_midpoint_xy.statistic[0, 0]
+            self.results.memb_midpoint[self._frame_index] = memb_midpoint_xy.statistic if self.n_bins > 1 else memb_midpoint_xy.statistic[0, 0]
 
         # The height in z of each lipid is calculated as the mean heigh
         # of its selected atoms

--- a/tests/lipyphilic/analysis/test_order_parameter.py
+++ b/tests/lipyphilic/analysis/test_order_parameter.py
@@ -117,7 +117,7 @@ class TestSCCExceptions:
     }
 
     def test_Exceptions(self, universe):
-        match = "'normals' must be a 3D array containing local membrane normals of each lipi at each frame."
+        match = "'normals' must be a 3D array containing local membrane normals of each lipid at each frame."
         with pytest.raises(ValueError, match=match):
             SCC(
                 universe=universe,

--- a/tests/lipyphilic/analysis/test_z_positions.py
+++ b/tests/lipyphilic/analysis/test_z_positions.py
@@ -111,3 +111,13 @@ class TestZPositionsUndulating:
 
         assert z_positions.results.z_positions.shape == (reference["n_residues"], reference["n_frames"])
         assert_array_equal(z_positions.results.z_positions, reference["z_positions"])
+    
+    def test_return_memb_midpoint(self, universe):
+        reference = {
+            "memb_midpoint": np.full((1, 10, 10), fill_value=50)
+        }
+        reference["memb_midpoint"][0, 3:7, 2:8] = 55
+        z_positions = ZPositions(universe, return_midpoint=True, **self.kwargs)
+        z_positions.run()
+        assert z_positions.memb_midpoint.shape == reference["memb_midpoint"].shape
+        assert_array_equal(z_positions.memb_midpoint, reference["memb_midpoint"])


### PR DESCRIPTION
Changes made in this Pull Request:
 - Fixes [#143](https://github.com/p-j-smith/lipyphilic/issues/143)
 - [Add return_midpoint](https://github.com/p-j-smith/lipyphilic/commit/2882db5c6708ccb5a8bb3e0ed89af867c421dfdf) to `Zpositions` similar to `return_surface` from `MembThickness`.
 - [Fix error with return_surface=True and n_bins=1](https://github.com/p-j-smith/lipyphilic/commit/6da77c181fda4f2c5151f8ef4c080530a83f9e5a)

PR Checklist
------------
 - [x] Tests added and passing? Except `test_memb_thickness.py::TestMembThicknessUndulating::test_nbins200_no_interpolation`
 - [x] Docs added and building?
 - [ ] CHANGELOG updated?
 - [x] AUTHORS updated if necessary?
 - [x] Issue raised and referenced?
