### PR TITLE
Rename `center_membrane` transformation to `CentreMembrane`

### DIFF
--- a/docs/reference/analyses.rst
+++ b/docs/reference/analyses.rst
@@ -436,7 +436,7 @@ while iterating over a trajectory. These are available in the module :mod:`lipyp
 
 There is currently one transformation available in **lipyphilic**:
 
-1. | :class:`lipyphilic.transformations.transformations.center_membrane`, which can take a membrane that is split
+1. | :class:`lipyphilic.transformations.transformations.CentreMembrane`, which can take a membrane that is split
    | across periodic boundaries, make it whole and center it in the box.
 
 See :mod:`lipyphilic.transformations.transformations.` for full details on this transformation including how to apply

--- a/src/lipyphilic/transformations/__init__.py
+++ b/src/lipyphilic/transformations/__init__.py
@@ -1,5 +1,5 @@
-from lipyphilic.transformations.transformations import center_membrane
+from lipyphilic.transformations.transformations import CentreMembrane, center_membrane
 
 __all__ = [
-    "center_membrane",
+    "CentreMembrane",
 ]

--- a/src/lipyphilic/transformations/transformations.py
+++ b/src/lipyphilic/transformations/transformations.py
@@ -54,6 +54,7 @@ Note
 
 """
 
+import warnings
 
 from MDAnalysis.transformations.base import TransformationBase
 import numpy as np
@@ -61,6 +62,30 @@ import numpy as np
 __all__ = [
     "CentreMembrane",
 ]
+
+
+class center_membrane:  # noqa: N801
+    """The class is deprecated. Please use `lipyphilic.transformations.CentreMembrane."""
+
+    def __init__(self, ag, shift=20, center_x=False, center_y=False, center_z=True, min_diff=10):
+        _msg = (
+            "`lipyphilic.transformations.center_membrane` has been renamed and will be removed "
+            "in a later version. Please use `lipyphilic.transformations.CentreMembrane` instead."
+        )
+        warnings.warn(
+            _msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return CentreMembrane(  # noqa: PLE0101
+            ag=ag,
+            shift=shift,
+            center_x=center_x,
+            center_y=center_y,
+            center_z=center_z,
+            min_diff=min_diff,
+        )
 
 
 class CentreMembrane(TransformationBase):
@@ -83,7 +108,16 @@ class CentreMembrane(TransformationBase):
 
     """
 
-    def __init__(self, ag, shift=20, center_x=False, center_y=False, center_z=True, min_diff=10):
+    def __init__(
+            self,
+            ag,
+            shift=20,
+            center_x=False,
+            center_y=False,
+            center_z=True,
+            min_diff=10,
+            max_threads=None,
+        ):
         """
 
         Parameters
@@ -106,13 +140,17 @@ class CentreMembrane(TransformationBase):
         center_z : bool, optional
             If true, the membrane will be iteratively shifted in z until it is
             not longer split across periodic boundaries.
+        max_threads: int, optional
+           The maximum thread number can be used.
+           Default is ``None``, which means the default or the external setting.
 
         Returns
         -------
-        :class:`MDAnalysis.coordinates.base.Timestep` object
+        :class:`MDAnalysis.coordinates.timestep.Timestep` object
+
 
         """
-
+        super().__init__(max_threads=max_threads, parallelizable=True)
         self.membrane = ag
         self.shift = shift
         self.center_xyz = np.array([center_x, center_y, center_z], dtype=bool)

--- a/src/lipyphilic/transformations/transformations.py
+++ b/src/lipyphilic/transformations/transformations.py
@@ -16,7 +16,7 @@ with MDAnalysis.
 Fix membranes broken across periodic boundaries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The callable class :class:`center_membrane` can be used to fix a membrane
+The callable class :class:`CentreMembrane` can be used to fix a membrane
 split across periodic boundaries and then center it in the unit cell. The membrane is iteratively
 shifted along a dimension until it is no longer split across periodic boundaries. It is then
 moved it to the center of the box in this dimension.
@@ -33,7 +33,7 @@ MDAnalysis:
 
   ag = u.select_atoms("resname DPPC DOPC CHOL")
 
-  u.trajectory.add_transformations(lpp.transformations.center_membrane(ag))
+  u.trajectory.add_transformations(lpp.transformations.CentreMembrane(ag))
 
 This will center a DPPC/DOPC/cholesterol membrane in :math:`z` every time a new frame is loaded
 into memory by MDAnalysis, such as when you iterate over the trajectory:
@@ -55,14 +55,15 @@ Note
 """
 
 
+from MDAnalysis.transformations.base import TransformationBase
 import numpy as np
 
 __all__ = [
-    "center_membrane",
+    "CentreMembrane",
 ]
 
 
-class center_membrane:  # noqa: N801
+class CentreMembrane(TransformationBase):
     """Fix a membrane split across periodic boundaries and center it in the primary unit cell.
 
     If, for example, the bilayer is split across :math:`z`, it will be iteratively
@@ -118,10 +119,10 @@ class center_membrane:  # noqa: N801
         self.min_diff = min_diff
 
         if not np.allclose(self.membrane.universe.dimensions[3:], 90.0):
-            _msg = "center_membrane requires an orthorhombic box - triclinic systems are not supported."
+            _msg = "CentreMembrane requires an orthorhombic box - triclinic systems are not supported."
             raise ValueError(_msg)
 
-    def __call__(self, ts):
+    def _tranform(self, ts):
         """Fix a membrane split across periodic boundaries."""
 
         self.membrane.universe.atoms.wrap(inplace=True)

--- a/src/lipyphilic/transformations/transformations.py
+++ b/src/lipyphilic/transformations/transformations.py
@@ -160,7 +160,7 @@ class CentreMembrane(TransformationBase):
             _msg = "CentreMembrane requires an orthorhombic box - triclinic systems are not supported."
             raise ValueError(_msg)
 
-    def _tranform(self, ts):
+    def _transform(self, ts):
         """Fix a membrane split across periodic boundaries."""
 
         self.membrane.universe.atoms.wrap(inplace=True)

--- a/tests/lipyphilic/transformations/test_transformations.py
+++ b/tests/lipyphilic/transformations/test_transformations.py
@@ -7,7 +7,7 @@ from lipyphilic._simple_systems.simple_systems import (
     TRICLINIC,
 )
 from lipyphilic.transformations import (
-    center_membrane,
+    CentreMembrane,
 )
 
 
@@ -38,7 +38,7 @@ class TestCenterMembrane:
     def test_center_frame(self, universe):
         membrane = universe.select_atoms("name L C")
         ts = universe.trajectory[0]
-        center_membrane(ag=membrane, shift=5)(ts)
+        CentreMembrane(ag=membrane, shift=5)(ts)
 
         upper_z_pos = universe.atoms.positions[self.reference["upper_leaflet"], 2]
         lower_z_pos = universe.atoms.positions[self.reference["lower_leaflet"], 2]
@@ -52,7 +52,7 @@ class TestCenterMembrane:
         universe = MDAnalysis.Universe(HEX_LAT_SPLIT_Z)
 
         membrane = universe.select_atoms("name L C")
-        universe.trajectory.add_transformations(center_membrane(ag=membrane))
+        universe.trajectory.add_transformations(CentreMembrane(ag=membrane))
 
         upper_z_pos = universe.atoms.positions[self.reference["upper_leaflet"], 2]
         lower_z_pos = universe.atoms.positions[self.reference["lower_leaflet"], 2]
@@ -65,8 +65,8 @@ class TestCenterMembrane:
     def test_exceptions(self):
         universe_triclinic = MDAnalysis.Universe(TRICLINIC)
 
-        match = "center_membrane requires an orthorhombic box"
+        match = "CentreMembrane requires an orthorhombic box"
         with pytest.raises(ValueError, match=match):
             universe_triclinic.trajectory.add_transformations(
-                center_membrane(ag=universe_triclinic.atoms),
+                CentreMembrane(ag=universe_triclinic.atoms),
             )


### PR DESCRIPTION
Fixes #

Changes made in this Pull Request:
 - add a deprecation warning for the `center_membrane` transformation
 - add a new `CentreMembrane` transformation. It is the same as `center_membrane` except it also takes a `max_threads` argument for running the transformation across multiple threads


PR Checklist
------------
 - [ ] Tests added and passing?
 - [ ] Docs added and building?
 - [ ] CHANGELOG updated?
 - [ ] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
