### PR TITLE
Add neighbor selection functionality to AreaPerLipid analysis

### DIFF
--- a/src/lipyphilic/analysis/area_per_lipid.py
+++ b/src/lipyphilic/analysis/area_per_lipid.py
@@ -98,6 +98,29 @@ The results are then available in the :attr:`areas.areas` attribute as a
 to an individual frame, i.e `areas.areas[i, j]` contains the area of lipid *i*
 at frame *j*.
 
+Excluding protein and solvent
+------------------------------
+
+By default, the Voronoi tessellation only considers lipid atoms when calculating area per lipid.
+However, in systems containing proteins or solvent molecules, these can be included in the
+tessellation to account for the space they occupy, effectively reducing the area of the lipids.
+Use the `exclude_sel` and `exclude_cutoff` parameters to include and control the influence
+of non-lipid atoms::
+
+  # Include protein atoms within 10 Angstroms of lipids in the tessellation
+  areas = AreaPerLipid(
+    universe=u,
+    lipid_sel="name GL1 GL2 ROH",
+    leaflets=leaflets.leaflets,
+    exclude_sel="protein",
+    exclude_cutoff=10.0
+  )
+  areas.run()
+
+Setting `exclude_cutoff` ensures that only excluded atoms in close proximity to the leaflet
+are included, which prevents hovering atoms of the protein far from the membrane to
+artificially reduce the calculated area per lipid when they are projected onto the leaflet.
+
 Warning
 -------
 If your membrane is highly curved the calculated area per lipid will be inaccurate.
@@ -133,8 +156,8 @@ class AreaPerLipid(AnalysisBase):
         universe: "MDAnalysis.Universe",
         lipid_sel: str,
         leaflets: np.ndarray,
-        neighbors_sel: str | None = None,
-        neighbor_cutoff: float = 0,
+        exclude_sel: str  = "",
+        exclude_cutoff: float = 0,
     ):
         """Set up parameters for calculating areas.
 
@@ -155,12 +178,13 @@ class AreaPerLipid(AnalysisBase):
             of shape (n_lipids, n_frames), the leaflet to which each lipid is
             assisgned at each frame will be taken into account when calculating
             the area per lipid.
-        neighbors_sel : str, optional
-            Atom selection for atoms to be considered as neighbors in the Voronoi tessellation.
-            This may be used to exclude protein or solvent atoms from the area calculation.
-        neighbor_cutoff : float, optional
-            Cutoff distance in Angstroms for including neighbor atoms in the Voronoi tessellation.
-            This is necessary to ensure that only neighbor atoms in the same leaflet as the lipids are included.
+        exclude_sel : str, optional
+            Atom selection to be excluded from contributing to lipid area in the Voronoi tessellation.
+            This may be used to account for protein or solvent atoms that occupy space in the membrane.
+        exclude_cutoff : float, optional
+            Cutoff distance from the leaflet in Angstroms for the excluded atoms.
+            This is necessary to ensure that excluded atoms are in close proximity to the leaflet.
+            By default, all excluded atoms are used for both leaflets (no cutoff).
 
         Tip
         ---
@@ -172,8 +196,8 @@ class AreaPerLipid(AnalysisBase):
 
         self.u = universe
         self.membrane = self.u.select_atoms(lipid_sel, updating=False)
-        self.neighbors = self.u.select_atoms(neighbors_sel) if neighbors_sel else None
-        self.cutoff = neighbor_cutoff
+        self.excluded = self.u.select_atoms(exclude_sel)
+        self.exclude_cutoff = exclude_cutoff
 
         if not np.allclose(self.u.dimensions[3:], 90.0):
             _msg = "AreaPerLipid requires an orthorhombic box - triclinic systems are not supported."
@@ -227,8 +251,8 @@ class AreaPerLipid(AnalysisBase):
     def _single_frame(self):
         # Atoms must be wrapped before creating a lateral grid of the membrane
         self.membrane.wrap(inplace=True)
-        if self.neighbors:
-            self.neighbors.wrap(inplace=True)
+        if self.excluded:
+            self.excluded.wrap(inplace=True)
         frame_leaflets = self.leaflets[:, self._frame_index] if self.leaflets.ndim == 2 else self.leaflets
 
         # Calculate area per lipid for the lower (-1) and upper (1) leaflets
@@ -237,9 +261,9 @@ class AreaPerLipid(AnalysisBase):
             # freud.order.Voronoi requires z positions set to 0
             leaflet = self.membrane.residues[frame_leaflets == leaflet_sign].atoms
             atoms = leaflet.atoms.intersection(self.membrane)
-            if self.neighbors:
-                filter_neighbors = self._filter_neighbors(atoms)
-                atoms = atoms.union(filter_neighbors)
+            if self.excluded:
+                filter_excluded = self._filter_exclude(atoms)
+                atoms = atoms.union(filter_excluded)
             pos = atoms.positions
             pos[:, 2] = 0
 
@@ -365,15 +389,15 @@ class AreaPerLipid(AnalysisBase):
 
             self.results.areas[species_resindices, self._frame_index] = species_apl
 
-    def _filter_neighbors(self, lipids: "MDAnalysis.AtomGroup") -> "MDAnalysis.AtomGroup":
-        """Filter neighbor atoms by distance from the lipids."""
-        if self.cutoff > 0:
-            filtered_neighbors = self.neighbors.select_atoms(
-                f"around {self.cutoff} global group leaflet",
+    def _filter_exclude(self, lipids: "MDAnalysis.AtomGroup") -> "MDAnalysis.AtomGroup":
+        """Filter excluded atoms by distance from the lipids."""
+        if self.exclude_cutoff > 0:
+            filtered_exclude = self.excluded.select_atoms(
+                f"around {self.exclude_cutoff} global group leaflet",
                 leaflet=lipids,
             )
-            return filtered_neighbors
-        return self.neighbors
+            return filtered_exclude
+        return self.excluded
 
 
     def project_area(
@@ -537,12 +561,12 @@ class AreaPerLipid(AnalysisBase):
             filter_by
         ]  # some molecules may be midplane during the period considered
 
-        # If neighbor atoms were provided, include their positions with zero value
+        # If excluded atoms were provided, include their positions with zero value
         # so that they appear as zero-area seeds in the projection.
-        if self.neighbors:
-            filter_neighbors = self._filter_neighbors(lipids)
-            n_x, n_y, _ = filter_neighbors.positions.T
-            # Append neighbor positions with zero values
+        if self.excluded:
+            filter_excluded = self._filter_exclude(lipids)
+            n_x, n_y, _ = filter_excluded.positions.T
+            # Append excluded positions with zero values
             lipids_xpos = np.concatenate((lipids_xpos, n_x))
             lipids_ypos = np.concatenate((lipids_ypos, n_y))
             values = np.concatenate((values, np.zeros(n_x.shape[0], dtype=float)))

--- a/src/lipyphilic/analysis/area_per_lipid.py
+++ b/src/lipyphilic/analysis/area_per_lipid.py
@@ -114,6 +114,7 @@ The class and its methods
 
 """
 import freud.locality
+import MDAnalysis
 from MDAnalysis.analysis.base import AnalysisBase
 import numpy as np
 
@@ -129,9 +130,11 @@ class AreaPerLipid(AnalysisBase):
 
     def __init__(
         self,
-        universe,
-        lipid_sel,
-        leaflets,
+        universe: "MDAnalysis.Universe",
+        lipid_sel: str,
+        leaflets: np.ndarray,
+        neighbors_sel: str | None = None,
+        neighbor_cutoff: float = 0,
     ):
         """Set up parameters for calculating areas.
 
@@ -152,6 +155,12 @@ class AreaPerLipid(AnalysisBase):
             of shape (n_lipids, n_frames), the leaflet to which each lipid is
             assisgned at each frame will be taken into account when calculating
             the area per lipid.
+        neighbors_sel : str, optional
+            Atom selection for atoms to be considered as neighbors in the Voronoi tessellation.
+            This may be used to exclude protein or solvent atoms from the area calculation.
+        neighbor_cutoff : float, optional
+            Cutoff distance in Angstroms for including neighbor atoms in the Voronoi tessellation.
+            This is necessary to ensure that only neighbor atoms in the same leaflet as the lipids are included.
 
         Tip
         ---
@@ -163,6 +172,8 @@ class AreaPerLipid(AnalysisBase):
 
         self.u = universe
         self.membrane = self.u.select_atoms(lipid_sel, updating=False)
+        self.neighbors = self.u.select_atoms(neighbors_sel) if neighbors_sel else None
+        self.cutoff = neighbor_cutoff
 
         if not np.allclose(self.u.dimensions[3:], 90.0):
             _msg = "AreaPerLipid requires an orthorhombic box - triclinic systems are not supported."
@@ -216,6 +227,8 @@ class AreaPerLipid(AnalysisBase):
     def _single_frame(self):
         # Atoms must be wrapped before creating a lateral grid of the membrane
         self.membrane.wrap(inplace=True)
+        if self.neighbors:
+            self.neighbors.wrap(inplace=True)
         frame_leaflets = self.leaflets[:, self._frame_index] if self.leaflets.ndim == 2 else self.leaflets
 
         # Calculate area per lipid for the lower (-1) and upper (1) leaflets
@@ -224,6 +237,9 @@ class AreaPerLipid(AnalysisBase):
             # freud.order.Voronoi requires z positions set to 0
             leaflet = self.membrane.residues[frame_leaflets == leaflet_sign].atoms
             atoms = leaflet.atoms.intersection(self.membrane)
+            if self.neighbors:
+                filter_neighbors = self._filter_neighbors(atoms)
+                atoms = atoms.union(filter_neighbors)
             pos = atoms.positions
             pos[:, 2] = 0
 
@@ -241,7 +257,7 @@ class AreaPerLipid(AnalysisBase):
                 atom_areas=areas,
             )
 
-    def _remove_overlapping(self, positions):
+    def _remove_overlapping(self, positions: np.ndarray) -> None:
         """Ensure no two atoms are overlapping in the xy plane.
 
         Given an Nx3 array of atomic positions, make minor adjustments to xy positions
@@ -279,7 +295,7 @@ class AreaPerLipid(AnalysisBase):
                 positions[duplicate_index, 0] += 0.001
 
 
-    def _get_atom_areas(self, positions):
+    def _get_atom_areas(self, positions: np.ndarray) -> np.ndarray:
         """Calculate area per atom.
 
         Given xy coordinates of atomic positions, perform a Voronoi
@@ -311,7 +327,7 @@ class AreaPerLipid(AnalysisBase):
 
         return areas
 
-    def _get_area_per_lipid(self, atoms, atom_areas):
+    def _get_area_per_lipid(self, atoms: "MDAnalysis.AtomGroup", atom_areas: np.ndarray) -> None:
         """Calculate the area per lipid given the areas of every Voronoi cell in a tessellation.
 
         This involves summing contributions from each atom of a given lipid.
@@ -349,6 +365,16 @@ class AreaPerLipid(AnalysisBase):
 
             self.results.areas[species_resindices, self._frame_index] = species_apl
 
+    def _filter_neighbors(self, lipids: "MDAnalysis.AtomGroup") -> "MDAnalysis.AtomGroup":
+        """Filter neighbor atoms by distance from the lipids."""
+        if self.cutoff > 0:
+            filtered_neighbors = self.neighbors.select_atoms(
+                f"around {self.cutoff} global group leaflet",
+                leaflet=lipids,
+            )
+            return filtered_neighbors
+        return self.neighbors
+
 
     def project_area(
         self,
@@ -363,6 +389,7 @@ class AreaPerLipid(AnalysisBase):
         vmin=None,
         vmax=None,
         cbar=True,
+        interpolate_kws=None,
         cbar_kws=None,
         imshow_kws=None,
     ):
@@ -440,6 +467,9 @@ class AreaPerLipid(AnalysisBase):
             data.
         cbar : bool, optional
             Whether or not to add a colorbar to the plot.
+        interpolate_kws : dict, optional
+            A dictionary of keyword options to pass to `scipy.interpolate.griddata`, which is used
+            to interpolate the projected areas across periodic boundaries.
         cbar_kws : dict, optional
             A dictionary of keyword options to pass to matplotlib.pyplot.colorbar.
         imshow_kws : dict, optional
@@ -507,6 +537,15 @@ class AreaPerLipid(AnalysisBase):
             filter_by
         ]  # some molecules may be midplane during the period considered
 
+        # If neighbor atoms were provided, include their positions with zero value
+        # so that they appear as zero-area seeds in the projection.
+        if self.neighbors:
+            filter_neighbors = self._filter_neighbors(lipids)
+            n_x, n_y, _ = filter_neighbors.positions.T
+            # Append neighbor positions with zero values
+            lipids_xpos = np.concatenate((lipids_xpos, n_x))
+            lipids_ypos = np.concatenate((lipids_ypos, n_y))
+            values = np.concatenate((values, np.zeros(n_x.shape[0], dtype=float)))
         # And finally we can create our ProjectionPlot
         area_projection = ProjectionPlot(lipids_xpos, lipids_ypos, values)
 
@@ -522,7 +561,8 @@ class AreaPerLipid(AnalysisBase):
 
         area_projection.project_values(bins=bins)
 
-        area_projection.interpolate()
+        interpolate_kws = interpolate_kws or {}
+        area_projection.interpolate(**interpolate_kws)
         area_projection.plot_projection(
             ax=ax,
             cmap=cmap,

--- a/tests/lipyphilic/analysis/test_area_per_lipid.py
+++ b/tests/lipyphilic/analysis/test_area_per_lipid.py
@@ -46,6 +46,54 @@ class TestAreaPerLipid:
         assert_array_almost_equal(areas.results.areas, 200.0, decimal=8)
 
 
+class TestAreaPerLipidNeighbors:
+    @staticmethod
+    def _universe():
+        universe = MDAnalysis.Universe.empty(
+            n_atoms=3,
+            n_residues=3,
+            atom_resindex=np.array([0, 1, 2]),
+            trajectory=True,
+        )
+        universe.add_TopologyAttr("names", ["L1", "L2", "P1"])
+        universe.add_TopologyAttr("resnames", ["LIP", "LIP", "PRO"])
+        universe.add_TopologyAttr("resids", [1, 2, 3])
+        universe.atoms.positions = np.array(
+            [
+                [2.0, 5.0, 5.0],
+                [8.0, 5.0, 5.0],
+                [5.0, 7.0, 5.0],
+            ]
+        )
+        universe.dimensions = np.array([10.0, 10.0, 10.0,
+                                        90.0, 90.0, 90.0])
+        return universe
+
+    def test_neighbors_influence_voronoi_cells(self):
+        leaflets = np.array([1, -1])
+
+        areas_without_neighbors = AreaPerLipid(
+            universe=self._universe(),
+            lipid_sel="resname LIP",
+            leaflets=leaflets,
+        )
+        areas_without_neighbors.run()
+
+        areas_with_neighbors = AreaPerLipid(
+            universe=self._universe(),
+            lipid_sel="resname LIP",
+            leaflets=leaflets,
+            neighbors_sel="resname PRO",
+        )
+        areas_with_neighbors.run()
+        apl_total = 10 * 10 * 2  # x * y * 2 leaflets
+        assert_array_almost_equal(areas_without_neighbors.results.areas.sum(), apl_total, decimal=8)
+        # Each leaflet area should be halved by the presence of the neighbor
+        assert areas_with_neighbors.results.areas.sum() < areas_without_neighbors.results.areas.sum()
+        apl_total_with_neighbors = apl_total / 2
+        assert_array_almost_equal(areas_with_neighbors.results.areas.sum(), apl_total_with_neighbors, decimal=8)
+
+
 class TestAreaPerLipidOverlapping:
     @staticmethod
     @pytest.fixture(scope="class")

--- a/tests/lipyphilic/analysis/test_area_per_lipid.py
+++ b/tests/lipyphilic/analysis/test_area_per_lipid.py
@@ -58,6 +58,8 @@ class TestAreaPerLipidNeighbors:
         universe.add_TopologyAttr("names", ["L1", "L2", "P1"])
         universe.add_TopologyAttr("resnames", ["LIP", "LIP", "PRO"])
         universe.add_TopologyAttr("resids", [1, 2, 3])
+        universe.add_TopologyAttr("masses", [1, 1, 2])
+        universe.add_TopologyAttr("bonds", [])
         universe.atoms.positions = np.array(
             [
                 [2.0, 5.0, 5.0],
@@ -72,12 +74,15 @@ class TestAreaPerLipidNeighbors:
     def test_neighbors_influence_voronoi_cells(self):
         leaflets = np.array([1, -1])
 
-        areas_without_neighbors = AreaPerLipid(
+        areas_no_neighbors = AreaPerLipid(
             universe=self._universe(),
             lipid_sel="resname LIP",
             leaflets=leaflets,
         )
-        areas_without_neighbors.run()
+        areas_no_neighbors.run()
+        areas_no_neighbors_sum = areas_no_neighbors.results.areas.sum()
+        apl_total = 10 * 10 * 2  # x * y * 2 leaflets
+        assert_array_almost_equal(areas_no_neighbors_sum, apl_total, decimal=8)
 
         areas_with_neighbors = AreaPerLipid(
             universe=self._universe(),
@@ -86,13 +91,42 @@ class TestAreaPerLipidNeighbors:
             neighbors_sel="resname PRO",
         )
         areas_with_neighbors.run()
-        apl_total = 10 * 10 * 2  # x * y * 2 leaflets
-        assert_array_almost_equal(areas_without_neighbors.results.areas.sum(), apl_total, decimal=8)
         # Each leaflet area should be halved by the presence of the neighbor
-        assert areas_with_neighbors.results.areas.sum() < areas_without_neighbors.results.areas.sum()
+        assert areas_with_neighbors.results.areas.sum() < areas_no_neighbors_sum
         apl_total_with_neighbors = apl_total / 2
         assert_array_almost_equal(areas_with_neighbors.results.areas.sum(), apl_total_with_neighbors, decimal=8)
 
+        # small cutoff excludes the PRO neighbor (distance ~3.605), so result equals no-neighbor case
+        areas_cutoff_small = AreaPerLipid(
+            universe=self._universe(),
+            lipid_sel="resname LIP",
+            leaflets=leaflets,
+            neighbors_sel="resname PRO",
+            neighbor_cutoff=3.0,
+        )
+        areas_cutoff_small.run()
+
+        assert_array_almost_equal(areas_cutoff_small.results.areas.sum(), areas_no_neighbors_sum, decimal=8)
+
+        # larger cutoff includes the neighbor; total area should same than with no cutoff
+        areas_cutoff_large = AreaPerLipid(
+            universe=self._universe(),
+            lipid_sel="resname LIP",
+            leaflets=leaflets,
+            neighbors_sel="resname PRO",
+            neighbor_cutoff=4.0,
+        )
+        areas_cutoff_large.run()
+
+        assert areas_cutoff_large.results.areas.sum() < areas_no_neighbors_sum
+        assert_array_almost_equal(areas_cutoff_large.results.areas.sum(), apl_total_with_neighbors, decimal=8)
+
+        area_projection = areas_cutoff_large.project_area()
+        assert isinstance(area_projection, ProjectionPlot)
+        # If we remove the zero values (which correspond to the neighbor's area),
+        # the result for the plotting is the same than for the apl
+        assert_array_almost_equal(area_projection.values[area_projection.values != 0],
+                                  areas_cutoff_large.results.areas.mean(), decimal=8)
 
 class TestAreaPerLipidOverlapping:
     @staticmethod

--- a/tests/lipyphilic/analysis/test_area_per_lipid.py
+++ b/tests/lipyphilic/analysis/test_area_per_lipid.py
@@ -46,7 +46,7 @@ class TestAreaPerLipid:
         assert_array_almost_equal(areas.results.areas, 200.0, decimal=8)
 
 
-class TestAreaPerLipidNeighbors:
+class TestAreaPerLipidExcluded:
     @staticmethod
     def _universe():
         universe = MDAnalysis.Universe.empty(
@@ -71,59 +71,59 @@ class TestAreaPerLipidNeighbors:
                                         90.0, 90.0, 90.0])
         return universe
 
-    def test_neighbors_influence_voronoi_cells(self):
+    def test_excluded_influence_voronoi_cells(self):
         leaflets = np.array([1, -1])
 
-        areas_no_neighbors = AreaPerLipid(
+        areas_no_excluded = AreaPerLipid(
             universe=self._universe(),
             lipid_sel="resname LIP",
             leaflets=leaflets,
         )
-        areas_no_neighbors.run()
-        areas_no_neighbors_sum = areas_no_neighbors.results.areas.sum()
+        areas_no_excluded.run()
+        areas_no_excluded_sum = areas_no_excluded.results.areas.sum()
         apl_total = 10 * 10 * 2  # x * y * 2 leaflets
-        assert_array_almost_equal(areas_no_neighbors_sum, apl_total, decimal=8)
+        assert_array_almost_equal(areas_no_excluded_sum, apl_total, decimal=8)
 
-        areas_with_neighbors = AreaPerLipid(
+        areas_with_excluded = AreaPerLipid(
             universe=self._universe(),
             lipid_sel="resname LIP",
             leaflets=leaflets,
-            neighbors_sel="resname PRO",
+            exclude_sel="resname PRO",
         )
-        areas_with_neighbors.run()
+        areas_with_excluded.run()
         # Each leaflet area should be halved by the presence of the neighbor
-        assert areas_with_neighbors.results.areas.sum() < areas_no_neighbors_sum
-        apl_total_with_neighbors = apl_total / 2
-        assert_array_almost_equal(areas_with_neighbors.results.areas.sum(), apl_total_with_neighbors, decimal=8)
+        assert areas_with_excluded.results.areas.sum() < areas_no_excluded_sum
+        apl_total_with_excluded = apl_total / 2
+        assert_array_almost_equal(areas_with_excluded.results.areas.sum(), apl_total_with_excluded, decimal=8)
 
         # small cutoff excludes the PRO neighbor (distance ~3.605), so result equals no-neighbor case
         areas_cutoff_small = AreaPerLipid(
             universe=self._universe(),
             lipid_sel="resname LIP",
             leaflets=leaflets,
-            neighbors_sel="resname PRO",
-            neighbor_cutoff=3.0,
+            exclude_sel="resname PRO",
+            exclude_cutoff=3.0,
         )
         areas_cutoff_small.run()
 
-        assert_array_almost_equal(areas_cutoff_small.results.areas.sum(), areas_no_neighbors_sum, decimal=8)
+        assert_array_almost_equal(areas_cutoff_small.results.areas.sum(), areas_no_excluded_sum, decimal=8)
 
         # larger cutoff includes the neighbor; total area should same than with no cutoff
         areas_cutoff_large = AreaPerLipid(
             universe=self._universe(),
             lipid_sel="resname LIP",
             leaflets=leaflets,
-            neighbors_sel="resname PRO",
-            neighbor_cutoff=4.0,
+            exclude_sel="resname PRO",
+            exclude_cutoff=4.0,
         )
         areas_cutoff_large.run()
 
-        assert areas_cutoff_large.results.areas.sum() < areas_no_neighbors_sum
-        assert_array_almost_equal(areas_cutoff_large.results.areas.sum(), apl_total_with_neighbors, decimal=8)
+        assert areas_cutoff_large.results.areas.sum() < areas_no_excluded_sum
+        assert_array_almost_equal(areas_cutoff_large.results.areas.sum(), apl_total_with_excluded, decimal=8)
 
         area_projection = areas_cutoff_large.project_area()
         assert isinstance(area_projection, ProjectionPlot)
-        # If we remove the zero values (which correspond to the neighbor's area),
+        # If we remove the zero values (which correspond to the exclude's area),
         # the result for the plotting is the same than for the apl
         assert_array_almost_equal(area_projection.values[area_projection.values != 0],
                                   areas_cutoff_large.results.areas.mean(), decimal=8)


### PR DESCRIPTION
Add neighbor selection for components like protein or solvent, to remove them from the APL calculations.

The selection can be passed as a string with the argument `neighbors_sel`, and then it can be refined per leaflet with the distance `neighbor_cutoff`.

The neighbors are also use in the plotting functions to set the areas to zero.

```
apl = AreaPerLipid(
    u,
    lipid_sel=membrane_sel,
    leaflets=leaflets,
    neighbors_sel=f'(around 10 {membrane_sel}) and not resname DPPC',
    neighbor_cutoff=10
)
apl.run(stop=10, verbose=True)

fig, (ax1, ax2, ax3) = plt.subplots(1,3, figsize=(18, 6))

ax1.set_title('Both Leaflet')
apl.project_area(cmap='inferno',
                 ax=ax1,
                 interpolate_kws={'method': 'nearest'})

ax2.set_title('Upper Leaflet')
apl.project_area(cmap='inferno',
                 ax=ax2,
                 interpolate_kws={'method': 'nearest'},
                 filter_by=leaflets==1)

ax3.set_title('Lower Leaflet')
apl.project_area(cmap='inferno',
                 ax=ax3,
                 interpolate_kws={'method': 'nearest'},
                 filter_by=leaflets==-1)
```
<img width="1404" height="490" alt="output" src="https://github.com/user-attachments/assets/65896a1f-f9ad-4076-8af1-a134754146fe" />

Fixes #
#148


PR Checklist
------------
 - [x] Tests added and passing?
 - [ ] Docs added and building?
 - [ ] CHANGELOG updated?
 - [x] AUTHORS updated if necessary?
 - [ ] Issue raised and referenced?
